### PR TITLE
Ignore backup archives in version control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Ignore backup archives and exported packages
+backups/
+backups/**/*.zip


### PR DESCRIPTION
## Summary
- add a .gitignore file to keep backup archives such as `backups/tmw-multi-feed-portraits-admin.v3.3V-Adultwebmaster69.zip` out of version control

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6c74b9be08324a717aeb69e805ce5