### PR TITLE
Harden LiveJasmin handlers and add actor migration tooling

### DIFF
--- a/admin/actions/ajax-get-embed-and-actors.php
+++ b/admin/actions/ajax-get-embed-and-actors.php
@@ -15,45 +15,57 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
  * @return void|array $output New post ID if success, -1 if not. Returned only if this function is called in PHP.
  */
 function lvjm_get_embed_and_actors( $params = '' ) {
-	$ajax_call = '' === $params;
+        $ajax_call = '' === $params;
 
-	if ( $ajax_call ) {
-		check_ajax_referer( 'ajax-nonce', 'nonce' );
-		$params = $_POST;
-	}
+        if ( $ajax_call ) {
+                check_ajax_referer( 'ajax-nonce', 'nonce' );
+                $params = isset( $_POST ) ? lvjm_recursive_sanitize_text_field( wp_unslash( $_POST ) ) : array();
+        } else {
+                $params = lvjm_recursive_sanitize_text_field( $params );
+        }
 
-	if ( ! isset( $params['video_id'] ) ) {
-		wp_die( 'Some parameters are missing!' );
-	}
+        if ( ! isset( $params['video_id'] ) || '' === $params['video_id'] ) {
+                wp_die( 'Some parameters are missing!' );
+        }
 
-	$output = array(
-		'performer_name' => '',
-		'embed'          => '',
-	);
+        $output = array(
+                'performer_name' => '',
+                'embed'          => '',
+        );
 
-	$saved_partner_options = WPSCORE()->get_product_option( 'LVJM', 'livejasmin_options' );
-	$psid                  = $saved_partner_options['psid'];
-	$access_key            = $saved_partner_options['accesskey'];
-	$primary_color         = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'primary-color' ) );
-	$label_color           = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'label-color' ) );
-	$client_ip             = '90.90.90.90';
-	$api_url               = 'https://pt.ptawe.com/api/video-promotion/v1/details/' . $params['video_id'] . '?clientIp=' . $client_ip . '&primaryColor=' . $primary_color . '&labelColor=' . $label_color . '&psid=' . $psid . '&accessKey=' . $access_key;
-	$args                  = array(
-		'timeout'   => 300,
-		'sslverify' => false,
-	);
+        $cache_key = 'embed_' . md5( (string) $params['video_id'] );
+        $cached    = wp_cache_get( $cache_key, 'lvjm_embed' );
+        if ( false !== $cached ) {
+                if ( ! $ajax_call ) {
+                        return $cached;
+                }
+                wp_send_json( $cached );
+                wp_die();
+        }
 
-	$response = wp_remote_get( $api_url, $args );
+        $saved_partner_options = WPSCORE()->get_product_option( 'LVJM', 'livejasmin_options' );
+        $psid                  = isset( $saved_partner_options['psid'] ) ? sanitize_text_field( (string) $saved_partner_options['psid'] ) : '';
+        $access_key            = isset( $saved_partner_options['accesskey'] ) ? sanitize_text_field( (string) $saved_partner_options['accesskey'] ) : '';
+        $primary_color         = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'primary-color' ) );
+        $label_color           = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'label-color' ) );
+        $client_ip             = '90.90.90.90';
+        $api_url               = 'https://pt.ptawe.com/api/video-promotion/v1/details/' . $params['video_id'] . '?clientIp=' . $client_ip . '&primaryColor=' . $primary_color . '&labelColor=' . $label_color . '&psid=' . $psid . '&accessKey=' . $access_key;
+        $args                  = array(
+                'timeout'   => 300,
+                'sslverify' => true,
+        );
 
-	if ( is_wp_error( $response ) ) {
+        $response = wp_remote_get( $api_url, $args );
+
+        if ( is_wp_error( $response ) ) {
 		return false;
 	}
-	$container_id    = 'lvjm-player-' . $params['video_id'];
-	$response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
+        $container_id    = 'lvjm-player-' . $params['video_id'];
+        $response_body   = json_decode( wp_remote_retrieve_body( $response ), true );
     // Use a responsive container for the player instead of fixed width/height.
     // Setting aspect-ratio to 16/9 and 100% width makes the embed responsive while
     // preserving the maximum width of 640px for backward compatibility.
-    $embed_container = '<div class="player" data-awe-container-id="' . $container_id . '" style="aspect-ratio:16/9;width:100%;"></div>';
+    $embed_container = '<div class="player" data-awe-container-id="' . $container_id . '" style="aspect-ratio:16/9;width:100%;" data-noptimize="true"></div>';
 
 	if ( ! isset( $response_body['data'], $response_body['data']['playerEmbedScript'] ) ) {
 		if ( $ajax_call ) {
@@ -63,7 +75,7 @@ function lvjm_get_embed_and_actors( $params = '' ) {
 		throw new Exception( 'AwEmpire Api not working' );
 	}
 
-	$embed_script = str_replace( '{CONTAINER}', $container_id, $response_body['data']['playerEmbedScript'] );
+        $embed_script = str_replace( '{CONTAINER}', $container_id, $response_body['data']['playerEmbedScript'] );
     // Append whitelabel redirect parameters directly into the embed script URL.  Without this
     // the player defaults to `siteId=jsm` which sends users to the main LiveJasmin domain.
     $whitelabel_id = ! empty( $saved_partner_options['whitelabel_id'] ) ? $saved_partner_options['whitelabel_id'] : '261146';
@@ -73,17 +85,19 @@ function lvjm_get_embed_and_actors( $params = '' ) {
     $embed_script = preg_replace_callback( '/<script\s+[^>]*src="([^"]+)"/', function ( $matches ) use ( $redirect_query ) {
         $src       = $matches[1];
         $delimiter = ( false === strpos( $src, '?' ) ) ? '?' : '&';
-        return '<script src="' . $src . $delimiter . $redirect_query . '"';
+        return '<script data-cfasync="false" data-noptimize="true" src="' . $src . $delimiter . $redirect_query . '"';
     }, $embed_script );
-	$output       = array(
-		'performer_name' => lvjm_get_performer_name_by_id( $response_body['data']['performerId'] ),
-		'embed'          => $embed_container . $embed_script,
-	);
-	if ( ! $ajax_call ) {
-		return $output;
-	}
-	wp_send_json( $output );
-	wp_die();
+        $output       = array(
+                'performer_name' => lvjm_get_performer_name_by_id( $response_body['data']['performerId'] ),
+                'embed'          => $embed_container . $embed_script,
+        );
+
+        wp_cache_set( $cache_key, $output, 'lvjm_embed', HOUR_IN_SECONDS );
+        if ( ! $ajax_call ) {
+                return $output;
+        }
+        wp_send_json( $output );
+        wp_die();
 }
 add_action( 'wp_ajax_lvjm_get_embed_and_actors', 'lvjm_get_embed_and_actors' );
 

--- a/admin/actions/ajax-import-video.php
+++ b/admin/actions/ajax-import-video.php
@@ -15,16 +15,60 @@ defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
  * @return void|array $output New post ID if success, -1 if not. Returned only if this function is called in PHP.
  */
 function lvjm_import_video( $params = '' ) {
-	$ajax_call = '' === $params;
+        $ajax_call = '' === $params;
 
-	if ( $ajax_call ) {
-		check_ajax_referer( 'ajax-nonce', 'nonce' );
-		$params = $_POST;
-	}
+        if ( $ajax_call ) {
+                check_ajax_referer( 'ajax-nonce', 'nonce' );
+                $params = wp_unslash( $_POST );
+        }
 
-	if ( ! isset( $params['partner_id'], $params['video_infos'], $params['status'], $params['feed_id'], $params['cat_s'], $params['cat_wp'] ) ) {
-		wp_die( 'Some parameters are missing!' );
-	}
+        $params = is_array( $params ) ? $params : array();
+
+        $params['partner_id'] = isset( $params['partner_id'] ) ? sanitize_text_field( (string) $params['partner_id'] ) : '';
+        $params['status']     = isset( $params['status'] ) ? sanitize_text_field( (string) $params['status'] ) : '';
+        $params['feed_id']    = isset( $params['feed_id'] ) ? sanitize_text_field( (string) $params['feed_id'] ) : '';
+        $params['cat_s']      = isset( $params['cat_s'] ) ? sanitize_text_field( (string) $params['cat_s'] ) : '';
+        $params['cat_wp']     = isset( $params['cat_wp'] ) ? absint( $params['cat_wp'] ) : 0;
+        $params['method']     = isset( $params['method'] ) ? sanitize_text_field( (string) $params['method'] ) : '';
+        $params['kw']         = isset( $params['kw'] ) ? absint( $params['kw'] ) : 0;
+
+        $video_infos = isset( $params['video_infos'] ) && is_array( $params['video_infos'] ) ? $params['video_infos'] : array();
+
+        $thumbs_urls = array();
+        if ( isset( $video_infos['thumbs_urls'] ) ) {
+                $raw_thumbs = is_array( $video_infos['thumbs_urls'] ) ? $video_infos['thumbs_urls'] : explode( ',', (string) $video_infos['thumbs_urls'] );
+                foreach ( (array) $raw_thumbs as $thumb_url ) {
+                        $thumb_url = esc_url_raw( trim( (string) $thumb_url ) );
+                        if ( ! empty( $thumb_url ) ) {
+                                $thumbs_urls[] = $thumb_url;
+                        }
+                }
+        }
+
+        $video_infos_sanitized = array(
+                'id'            => isset( $video_infos['id'] ) ? sanitize_text_field( (string) $video_infos['id'] ) : '',
+                'title'         => isset( $video_infos['title'] ) ? sanitize_text_field( (string) $video_infos['title'] ) : 'Untitled',
+                'desc'          => isset( $video_infos['desc'] ) ? wp_kses_post( $video_infos['desc'] ) : '',
+                'embed'         => isset( $video_infos['embed'] ) ? wp_kses_post( $video_infos['embed'] ) : '',
+                'thumb_url'     => isset( $video_infos['thumb_url'] ) ? esc_url_raw( (string) $video_infos['thumb_url'] ) : '',
+                'thumbs_urls'   => $thumbs_urls,
+                'trailer_url'   => isset( $video_infos['trailer_url'] ) ? esc_url_raw( (string) $video_infos['trailer_url'] ) : '',
+                'video_url'     => isset( $video_infos['video_url'] ) ? esc_url_raw( (string) $video_infos['video_url'] ) : '',
+                'tracking_url'  => isset( $video_infos['tracking_url'] ) ? esc_url_raw( (string) $video_infos['tracking_url'] ) : '',
+                'duration'      => isset( $video_infos['duration'] ) ? sanitize_text_field( (string) $video_infos['duration'] ) : '',
+                'quality'       => isset( $video_infos['quality'] ) ? sanitize_text_field( (string) $video_infos['quality'] ) : '',
+                'isHd'          => isset( $video_infos['isHd'] ) ? sanitize_text_field( (string) $video_infos['isHd'] ) : '',
+                'uploader'      => isset( $video_infos['uploader'] ) ? sanitize_text_field( (string) $video_infos['uploader'] ) : '',
+                'actors'        => isset( $video_infos['actors'] ) ? sanitize_text_field( (string) $video_infos['actors'] ) : '',
+                'tags'          => isset( $video_infos['tags'] ) ? sanitize_text_field( (string) $video_infos['tags'] ) : '',
+                'partner_cat'   => isset( $video_infos['partner_cat'] ) ? sanitize_text_field( (string) $video_infos['partner_cat'] ) : '',
+        );
+
+        $params['video_infos'] = $video_infos_sanitized;
+
+        if ( '' === $params['partner_id'] || empty( $params['video_infos'] ) || '' === $params['status'] || '' === $params['feed_id'] || '' === $params['cat_s'] ) {
+                wp_die( 'Some parameters are missing!' );
+        }
 
 	// get custom post type.
 	$custom_post_type = xbox_get_field_value( 'lvjm-options', 'custom-video-post-type' );
@@ -56,8 +100,10 @@ function lvjm_import_video( $params = '' ) {
 		update_post_meta( $post_id, 'video_id', (string) $params['video_infos']['id'] );
 		// add main thumb.
 		update_post_meta( $post_id, 'thumb', (string) $params['video_infos']['thumb_url'] );
-		// add partner_cat.
-		update_post_meta( $post_id, 'partner_cat', (string) $params['cat_s'] );
+                // add partner_cat.
+                $partner_cat_source     = ! empty( $params['video_infos']['partner_cat'] ) ? $params['video_infos']['partner_cat'] : (string) $params['cat_s'];
+                $normalized_partner_cat = lvjm_normalize_category_slug( $partner_cat_source );
+                update_post_meta( $post_id, 'partner_cat', $normalized_partner_cat );
 		// add feed.
 		update_post_meta( $post_id, 'feed', (string) $params['feed_id'] );
 		// add video length.
@@ -97,13 +143,10 @@ function lvjm_import_video( $params = '' ) {
 		}
 		wp_set_object_terms( $post_id, explode( ',', str_replace( ';', ',', (string) $params['video_infos']['tags'] ) ), LVJM()->call_by_ref( $custom_tags ), false );
 		// add actors.
-		$custom_actors = xbox_get_field_value( 'lvjm-options', 'custom-video-actors' );
-		if ( '' === $custom_actors ) { $custom_actors = 'models'; }
-		if ( 'actors' === $custom_actors ) { $custom_actors = 'models'; }
-
-		if ( '' === $custom_actors ) {
-			$custom_actors = 'actors';
-		}
+                $custom_actors = xbox_get_field_value( 'lvjm-options', 'custom-video-actors' );
+                if ( '' === $custom_actors || 'actors' === $custom_actors ) {
+                        $custom_actors = 'models';
+                }
 		if ( ! empty( $params['video_infos']['actors'] ) ) {
 			wp_set_object_terms( $post_id, explode( ',', str_replace( ';', ',', (string) $params['video_infos']['actors'] ) ), LVJM()->call_by_ref( $custom_actors ), false );
 		}

--- a/admin/actions/ajax-update-feed.php
+++ b/admin/actions/ajax-update-feed.php
@@ -20,10 +20,12 @@ function lvjm_update_feed( $params = '' ) {
 	$ajax_call          = '' === $params;
 	$last_update_method = $ajax_call ? 'manual' : 'auto';
 
-	if ( $ajax_call ) {
-		check_ajax_referer( 'ajax-nonce', 'nonce' );
-		$params = $_POST;
-	}
+        if ( $ajax_call ) {
+                check_ajax_referer( 'ajax-nonce', 'nonce' );
+                $params = isset( $_POST ) ? lvjm_recursive_sanitize_text_field( wp_unslash( $_POST ) ) : array();
+        } else {
+                $params = lvjm_recursive_sanitize_text_field( $params );
+        }
 
 	if ( ! isset( $params['feed_id'] ) ) {
 		wp_die( 'Some parameters are missing!' );

--- a/admin/class/class-lvjm-cli-commands.php
+++ b/admin/class/class-lvjm-cli-commands.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * WP-CLI commands for LiveJasmin plugin.
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'LVJM_CLI_Commands' ) ) {
+    /**
+     * Collection of WP-CLI helpers for the LiveJasmin integration.
+     */
+    class LVJM_CLI_Commands {
+        /**
+         * Migrate all "actors" taxonomy terms to "models".
+         *
+         * ## EXAMPLES
+         *
+         *     wp lvjm migrate-actors
+         *
+         * @return void
+         */
+        public static function migrate_actors_to_models() {
+            if ( ! class_exists( '\\WP_CLI' ) ) {
+                return;
+            }
+
+            $actors_taxonomy = 'actors';
+            $models_taxonomy = 'models';
+
+            if ( ! taxonomy_exists( $actors_taxonomy ) ) {
+                \WP_CLI::warning( sprintf( 'The "%s" taxonomy does not exist.', $actors_taxonomy ) );
+                return;
+            }
+
+            if ( ! taxonomy_exists( $models_taxonomy ) ) {
+                \WP_CLI::error( sprintf( 'The "%s" taxonomy does not exist.', $models_taxonomy ) );
+                return;
+            }
+
+            $custom_post_type = function_exists( 'xbox_get_field_value' ) ? xbox_get_field_value( 'lvjm-options', 'custom-video-post-type' ) : '';
+            if ( empty( $custom_post_type ) ) {
+                $custom_post_type = 'post';
+            }
+
+            $paged    = 1;
+            $per_page = 100;
+            $migrated = 0;
+            $created  = 0;
+
+            \WP_CLI::log( sprintf( 'Migrating performers from "%s" to "%s"...', $actors_taxonomy, $models_taxonomy ) );
+
+            do {
+                $query = new \WP_Query(
+                    array(
+                        'post_type'      => $custom_post_type,
+                        'posts_per_page' => $per_page,
+                        'paged'          => $paged,
+                        'post_status'    => 'any',
+                        'fields'         => 'ids',
+                        'tax_query'      => array(
+                            array(
+                                'taxonomy' => $actors_taxonomy,
+                                'operator' => 'EXISTS',
+                            ),
+                        ),
+                    )
+                );
+
+                if ( ! $query->have_posts() ) {
+                    break;
+                }
+
+                foreach ( $query->posts as $post_id ) {
+                    $terms = wp_get_object_terms( $post_id, $actors_taxonomy );
+                    if ( is_wp_error( $terms ) || empty( $terms ) ) {
+                        continue;
+                    }
+
+                    $target_term_ids = array();
+
+                    foreach ( $terms as $term ) {
+                        $target = term_exists( $term->slug, $models_taxonomy );
+                        if ( ! $target ) {
+                            $target = wp_insert_term(
+                                $term->name,
+                                $models_taxonomy,
+                                array(
+                                    'slug' => $term->slug,
+                                )
+                            );
+                            if ( is_wp_error( $target ) ) {
+                                \WP_CLI::warning( sprintf( 'Could not migrate term "%s": %s', $term->name, $target->get_error_message() ) );
+                                continue;
+                            }
+                            ++$created;
+                        }
+
+                        $target_term_ids[] = is_array( $target ) ? (int) $target['term_id'] : (int) $target;
+                    }
+
+                    if ( ! empty( $target_term_ids ) ) {
+                        wp_add_object_terms( $post_id, $target_term_ids, $models_taxonomy );
+                        wp_remove_object_terms( $post_id, wp_list_pluck( $terms, 'term_id' ), $actors_taxonomy );
+                        ++$migrated;
+                    }
+                }
+
+                ++$paged;
+                wp_cache_flush();
+            } while ( $paged <= $query->max_num_pages );
+
+            \WP_CLI::success( sprintf( 'Migrated %d posts. Created %d new model terms.', $migrated, $created ) );
+        }
+    }
+}

--- a/admin/class/class-lvjm-json-item.php
+++ b/admin/class/class-lvjm-json-item.php
@@ -8,6 +8,8 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
+require_once LVJM_DIR . 'admin/class/class-lvjm-placeholder-parser.php';
+
 /**
  * Json Item Class
  *
@@ -151,32 +153,26 @@ class LVJM_Json_Item {
 	 *
 	 * @return string|bool The feed info if success, false if not.
 	 */
-	private function get_partner_feed_infos( $partner_feed_item, $partner_id, $feed_infos ) {
+        private function get_partner_feed_infos( $partner_feed_item, $partner_id, $feed_infos ) {
 
-		$feed_item_type = isset( $feed_infos[ $partner_feed_item ] ) ? key( $feed_infos[ $partner_feed_item ] ) : null;
+                $feed_item_type = isset( $feed_infos[ $partner_feed_item ] ) ? key( $feed_infos[ $partner_feed_item ] ) : null;
 
-		if ( isset( $feed_infos[ $partner_feed_item ][ $feed_item_type ] ) ) {
-			$short_item = $feed_infos[ $partner_feed_item ][ $feed_item_type ];
-			$results    = array();
-			preg_match_all( '/<%(.+)%>/U', $short_item, $results );
+                if ( isset( $feed_infos[ $partner_feed_item ][ $feed_item_type ] ) ) {
+                        $template              = $feed_infos[ $partner_feed_item ][ $feed_item_type ];
+                        $saved_partner_options = WPSCORE()->get_product_option( 'LVJM', $partner_id . '_options' );
+                        $context               = array(
+                                'partner_options' => is_array( $saved_partner_options ) ? $saved_partner_options : array(),
+                                'params'          => $this->params,
+                                'item'            => $this->item,
+                                'item_all_data'   => $this->item_all_data,
+                        );
 
-			foreach ( $results[1] as $result ) {
-				if ( strpos( $result, 'get_partner_option' ) !== false ) {
-					$saved_partner_options = WPSCORE()->get_product_option( 'LVJM', $partner_id . '_options' );
-					$option                = str_replace( array( 'get_partner_option("', '")' ), array( '', '' ), $result );
-					$new_result            = '$saved_partner_options["' . $option . '"]';
-					$short_item            = str_replace( '<%' . $result . '%>', eval( 'return ' . $new_result . ';' ), $partner_feed_item );
+                        $short_item = LVJM_Placeholder_Parser::parse( $template, $context );
+                        switch ( $feed_item_type ) {
 
-				} else {
-					$short_item = str_replace( '<%' . $result . '%>', eval( 'return ' . $result . ';' ), $short_item );
-				}
-			}
-			unset( $results );
-			switch ( $feed_item_type ) {
-
-				case 'node':
-					if ( is_array( $this->item_all_data[ $short_item ] ) ) {
-						$output = isset( $this->item_all_data[ $short_item ][0] ) ? $this->item_all_data[ $short_item ][0] : '';
+                                case 'node':
+                                        if ( is_array( $this->item_all_data[ $short_item ] ) ) {
+                                                $output = isset( $this->item_all_data[ $short_item ][0] ) ? $this->item_all_data[ $short_item ][0] : '';
 					} else {
 						$output = isset( $this->item_all_data[ $short_item ] ) ? $this->item_all_data[ $short_item ] : '';
 					}

--- a/admin/class/class-lvjm-placeholder-parser.php
+++ b/admin/class/class-lvjm-placeholder-parser.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Helper to parse legacy template placeholders without eval().
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'LVJM_Placeholder_Parser' ) ) {
+    /**
+     * Replace <%%> placeholders with safe values.
+     */
+    class LVJM_Placeholder_Parser {
+        /**
+         * Replace placeholders in a template string.
+         *
+         * @param string $template Template containing placeholders.
+         * @param array  $context  Available variables for replacement.
+         * @return string
+         */
+        public static function parse( $template, array $context = array() ) {
+            return preg_replace_callback(
+                '/<%(.+?)%>/s',
+                function ( $matches ) use ( $context ) {
+                    return self::resolve_expression( $matches[1], $context );
+                },
+                $template
+            );
+        }
+
+        /**
+         * Resolve a single placeholder expression.
+         *
+         * @param string $expression Placeholder contents.
+         * @param array  $context    Context array.
+         * @return string
+         */
+        private static function resolve_expression( $expression, array $context ) {
+            $expression = trim( $expression );
+
+            if ( preg_match( "/^get_partner_option\((\"|')(.*?)(\1)\)$/", $expression, $matches ) ) {
+                $option  = $matches[2];
+                $options = isset( $context['partner_options'] ) && is_array( $context['partner_options'] ) ? $context['partner_options'] : array();
+                return isset( $options[ $option ] ) ? $options[ $option ] : '';
+            }
+
+            if ( preg_match( '/^\$this->([a-zA-Z0-9_]+)(.*)$/', $expression, $matches ) ) {
+                $root = $matches[1];
+                $path = $matches[2];
+                if ( isset( $context[ $root ] ) ) {
+                    return self::resolve_path( $context[ $root ], $path );
+                }
+            }
+
+            if ( preg_match( '/^\$([a-zA-Z0-9_]+)(.*)$/', $expression, $matches ) ) {
+                $root = $matches[1];
+                $path = $matches[2];
+                if ( isset( $context[ $root ] ) ) {
+                    return self::resolve_path( $context[ $root ], $path );
+                }
+            }
+
+            if ( preg_match( '/^"(.*)"$/s', $expression, $matches ) ) {
+                return stripslashes( $matches[1] );
+            }
+
+            if ( preg_match( "/^'(.*)'$/s", $expression, $matches ) ) {
+                return stripslashes( $matches[1] );
+            }
+
+            if ( is_numeric( $expression ) ) {
+                return $expression;
+            }
+
+            return '';
+        }
+
+        /**
+         * Resolve array/object access using bracket notation.
+         *
+         * @param mixed  $value Base value.
+         * @param string $path  Path string such as ["foo"][0].
+         * @return string
+         */
+        private static function resolve_path( $value, $path ) {
+            if ( '' === $path ) {
+                return self::scalar( $value );
+            }
+
+            preg_match_all( "/\[(\"([^\"]+)\"|'([^']+)'|([0-9]+))\]/", $path, $matches, PREG_SET_ORDER );
+            foreach ( $matches as $match ) {
+                $key = '';
+                if ( '' !== $match[2] ) {
+                    $key = $match[2];
+                } elseif ( '' !== $match[3] ) {
+                    $key = $match[3];
+                } else {
+                    $key = $match[4];
+                }
+
+                if ( is_array( $value ) && isset( $value[ $key ] ) ) {
+                    $value = $value[ $key ];
+                } elseif ( is_object( $value ) && isset( $value->{$key} ) ) {
+                    $value = $value->{$key};
+                } else {
+                    return '';
+                }
+            }
+
+            return self::scalar( $value );
+        }
+
+        /**
+         * Convert a value to a scalar string.
+         *
+         * @param mixed $value Value to convert.
+         * @return string
+         */
+        private static function scalar( $value ) {
+            if ( is_scalar( $value ) ) {
+                return (string) $value;
+            }
+
+            return '';
+        }
+    }
+}

--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -197,9 +197,13 @@ function LVJM_pageImportVideos() {
                 },
                 selectedPartnerObject: function () {
                     var self = this;
-                    return lodash.find(this.data.partners, function (p) {
+                    var partner = lodash.find(this.data.partners, function (p) {
                         return p.id == self.selectedPartner;
                     });
+                    if (!partner) {
+                        partner = { categories: [], filters: {} };
+                    }
+                    return partner;
                 },
                 checkedVideosCounter: function () {
                     return this.videos.filter(function (video) {
@@ -208,7 +212,7 @@ function LVJM_pageImportVideos() {
                 },
                 selectedPartnerCatName: function () {
                     var self = this;
-                    if (this.selectedPartnerObject != '') {
+                    if (this.selectedPartnerObject && this.selectedPartnerObject.categories) {
                         var name;
                         lodash.each(self.selectedPartnerObject.categories, function (c) {
                             if (lodash.has(c, 'sub_cats')) {
@@ -329,13 +333,8 @@ function LVJM_pageImportVideos() {
                 loadPartnerCats: function () {
                     this.partnerCatsLoading = true;
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
-    
+
                             LVJM_import_videos.ajax.url, {
                                 action: 'lvjm_load_partner_cats',
                                 nonce: LVJM_import_videos.ajax.nonce,
@@ -452,11 +451,6 @@ function LVJM_pageImportVideos() {
                     //jQuery('[rel=tooltip]').tooltip('hide');
 
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                             LVJM_import_videos.ajax.url, {
@@ -467,6 +461,7 @@ function LVJM_pageImportVideos() {
                                 kw: kw,
                                 limit: this.data.videosLimit,
                                 method: method,
+                                multi_category_search: this.selectedPartnerCats === 'all_straight' ? 1 : 0,
                                 nonce: LVJM_import_videos.ajax.nonce,
                                 original_cat_s: cat_s.replace('&', '%%'),
                                 partner: partner,
@@ -496,6 +491,7 @@ function LVJM_pageImportVideos() {
                                         actors: video.actors,
                                         tags: video.tags,
                                         video_url: video.video_url,
+                                        partner_cat: video.partner_cat || cat_s,
                                         checked: video.checked,
                                         grabbed: false,
                                         loading: {
@@ -593,11 +589,6 @@ function LVJM_pageImportVideos() {
                     video.loading.removing = true;
                     this.loading.removingVideo = true;
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                             LVJM_import_videos.ajax.url, {
@@ -813,11 +804,6 @@ function LVJM_pageImportVideos() {
                 deleteFeed: function () {
                     this.loading.deleteFeed = true;
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                             LVJM_import_videos.ajax.url, {
@@ -847,11 +833,6 @@ function LVJM_pageImportVideos() {
                 this.loading.loadingData = true;
                 var self = this;
                 
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                         LVJM_import_videos.ajax.url, {
@@ -1089,12 +1070,7 @@ function LVJM_pageImportVideos() {
                         saveOptions: function () {
                             this.loading.savingOptions = true;
                             
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
-                    this.$http.post(
+                        this.$http.post(
     
                                     LVJM_import_videos.ajax.url, {
                                         action: 'lvjm_save_partner_options',
@@ -1267,12 +1243,7 @@ function LVJM_pageImportVideos() {
                         changeStatus: function (newValue) {
                             this.loading.savingOptions = this.loading.savingStatus = true;
                             
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
-                    this.$http.post(
+                        this.$http.post(
     
                                     LVJM_import_videos.ajax.url, {
                                         action: 'lvjm_change_feed_status',
@@ -1295,12 +1266,7 @@ function LVJM_pageImportVideos() {
                         toggleAutoImport: function (newValue) {
                             this.loading.savingOptions = this.loading.savingAutoImport = true;
                             
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
-                    this.$http.post(
+                        this.$http.post(
     
                                     LVJM_import_videos.ajax.url, {
                                         action: 'lvjm_toggle_feed_auto_import',

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -1,6 +1,8 @@
 <?php
 
-error_log('[WPS-LiveJasmin] Import videos page accessed');
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+        error_log( '[WPS-LiveJasmin] Import videos page accessed' );
+}
 /**
  * Admin Import Page plugin file.
  *

--- a/config.php
+++ b/config.php
@@ -1,6 +1,8 @@
 <?php
 
-error_log('[WPS-LiveJasmin] Config loaded');
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+        error_log( '[WPS-LiveJasmin] Config loaded' );
+}
 /**
  * Config plugin file.
  *

--- a/public/actions.php
+++ b/public/actions.php
@@ -125,11 +125,8 @@ function lvjm_set_embed_redirect_and_responsiveness( $meta_value, $object_id, $m
                 update_post_meta( $object_id, $custom_embed_player, $more_data['embed'] );
                 // Assign actor
                 $custom_actors = xbox_get_field_value( 'lvjm-options', 'custom-video-actors' );
-		if ( '' === $custom_actors ) { $custom_actors = 'models'; }
-		if ( 'actors' === $custom_actors ) { $custom_actors = 'models'; }
-
-                if ( '' === $custom_actors ) {
-                    $custom_actors = 'actors';
+                if ( '' === $custom_actors || 'actors' === $custom_actors ) {
+                    $custom_actors = 'models';
                 }
                 if ( ! empty( $more_data['performer_name'] ) ) {
                     wp_add_object_terms( $object_id, $more_data['performer_name'], $custom_actors );
@@ -143,11 +140,23 @@ function lvjm_set_embed_redirect_and_responsiveness( $meta_value, $object_id, $m
         // Append redirect parameters to the first script tag
         $script_tag       = $script_tags[0];
         $script_tag->src .= '&' . http_build_query( $redirect_param );
+        if ( method_exists( $script_tag, 'setAttribute' ) ) {
+            $script_tag->setAttribute( 'data-cfasync', 'false' );
+            $script_tag->setAttribute( 'data-noptimize', 'true' );
+        } else {
+            $script_tag->attr['data-cfasync']   = 'false';
+            $script_tag->attr['data-noptimize'] = 'true';
+        }
         // Ensure player wrapper is responsive
         $div_tags = $meta_value_html_obj->find( 'div.player' );
         if ( 0 !== count( $div_tags ) ) {
             $div_tag        = $div_tags[0];
             $div_tag->style = 'width: 100% !important;height: auto !important;aspect-ratio: 16/9;';
+            if ( method_exists( $div_tag, 'setAttribute' ) ) {
+                $div_tag->setAttribute( 'data-noptimize', 'true' );
+            } else {
+                $div_tag->attr['data-noptimize'] = 'true';
+            }
         }
         return $meta_value_html_obj->__toString();
     };

--- a/wps-livejasmin.php
+++ b/wps-livejasmin.php
@@ -14,7 +14,9 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
-error_log('[WPS-LiveJasmin] Main plugin file loaded');
+if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+        error_log( '[WPS-LiveJasmin] Main plugin file loaded' );
+}
 
 if ( ! class_exists( 'LVJM' ) ) {
 	/**
@@ -685,13 +687,89 @@ add_action('admin_menu', function () {
 }, 999);
 
 add_action('admin_init', function(){
-	if (!is_admin()) return;
-	if (!current_user_can('manage_categories')) return;
-	$tax = isset($_GET['taxonomy']) ? sanitize_text_field(wp_unslash($_GET['taxonomy'])) : '';
-	if ($tax === 'actors') {
-		$pt  = isset($_GET['post_type']) ? sanitize_text_field(wp_unslash($_GET['post_type'])) : 'video';
-		$dst = add_query_arg(array('taxonomy'=>'models','post_type'=>$pt), admin_url('edit-tags.php'));
-		wp_safe_redirect($dst, 301);
-		exit;
-	}
+        if (!is_admin()) return;
+        if (!current_user_can('manage_categories')) return;
+        $tax = isset($_GET['taxonomy']) ? sanitize_text_field(wp_unslash($_GET['taxonomy'])) : '';
+        if ($tax === 'actors') {
+                $pt  = isset($_GET['post_type']) ? sanitize_text_field(wp_unslash($_GET['post_type'])) : 'video';
+                $dst = add_query_arg(array('taxonomy'=>'models','post_type'=>$pt), admin_url('edit-tags.php'));
+                wp_safe_redirect($dst, 301);
+                exit;
+        }
 });
+
+if ( ! function_exists( 'lvjm_recursive_sanitize_text_field' ) ) {
+        /**
+         * Recursively sanitize a value or array of values using sanitize_text_field.
+         *
+         * @param mixed $value Value to sanitize.
+         * @return mixed
+         */
+        function lvjm_recursive_sanitize_text_field( $value ) {
+                if ( is_array( $value ) ) {
+                        foreach ( $value as $key => $sub_value ) {
+                                $value[ $key ] = lvjm_recursive_sanitize_text_field( $sub_value );
+                        }
+                        return $value;
+                }
+
+                if ( is_object( $value ) ) {
+                        foreach ( $value as $property => $sub_value ) {
+                                $value->$property = lvjm_recursive_sanitize_text_field( $sub_value );
+                        }
+                        return $value;
+                }
+
+                if ( is_bool( $value ) ) {
+                        return (bool) $value;
+                }
+
+                if ( is_numeric( $value ) ) {
+                        return $value + 0;
+                }
+
+                return sanitize_text_field( (string) $value );
+        }
+}
+
+if ( ! function_exists( 'lvjm_normalize_category_slug' ) ) {
+        /**
+         * Normalize a partner category identifier to a slug compatible with the API/cache.
+         *
+         * @param string $category Category identifier from partner data.
+         * @return string
+         */
+        function lvjm_normalize_category_slug( $category ) {
+                $category = strtolower( trim( (string) $category ) );
+                // Replace separators and collapse whitespace.
+                $category = preg_replace( '/[\s_]+/', '-', $category );
+                $category = preg_replace( '/[^a-z0-9\-]/', '-', $category );
+                $category = preg_replace( '/-+/', '-', $category );
+                return trim( $category, '-' );
+        }
+}
+
+if ( ! function_exists( 'lvjm_get_straight_category_slugs' ) ) {
+        /**
+         * Retrieve normalized slugs for all straight partner categories.
+         *
+         * @return array
+         */
+        function lvjm_get_straight_category_slugs() {
+                $categories = array();
+                if ( function_exists( 'LVJM' ) ) {
+                        $raw_categories = LVJM()->get_partner_categories();
+                        if ( isset( $raw_categories['optgroup::Straight'] ) && is_array( $raw_categories['optgroup::Straight'] ) ) {
+                                foreach ( array_keys( $raw_categories['optgroup::Straight'] ) as $category_id ) {
+                                        $categories[ lvjm_normalize_category_slug( $category_id ) ] = $category_id;
+                                }
+                        }
+                }
+                return $categories;
+        }
+}
+
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+        require_once plugin_dir_path( __FILE__ ) . 'admin/class/class-lvjm-cli-commands.php';
+        WP_CLI::add_command( 'lvjm migrate-actors', array( 'LVJM_CLI_Commands', 'migrate_actors_to_models' ) );
+}


### PR DESCRIPTION
## Summary
- sanitize and nonce protect LiveJasmin AJAX entry points while adding caching for multi-category searches
- replace eval-based placeholder expansion with a safe parser, restore SSL verification, and harden embed handling for caching/CDN compatibility
- default performers to the models taxonomy and ship a WP-CLI migration command for legacy actors terms

## Testing
- php -l wps-livejasmin.php
- php -l config.php
- php -l admin/actions/ajax-search-videos.php
- php -l admin/actions/ajax-import-video.php
- php -l admin/actions/ajax-update-feed.php
- php -l admin/actions/ajax-get-embed-and-actors.php
- php -l admin/class/class-lvjm-search-videos.php
- php -l admin/class/class-lvjm-json-item.php
- php -l public/actions.php
- php -l admin/class/class-lvjm-cli-commands.php
- php -l admin/class/class-lvjm-placeholder-parser.php

------
https://chatgpt.com/codex/tasks/task_e_68d7a9db8fe483249dce298d64fb0b2a