### PR TITLE
Fix multi category search flag

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -90,7 +90,6 @@ function LVJM_pageImportVideos() {
 
                 partnerCatsLoading: false,
                 partnerCats: [],
-                selectedPartnerCats: '',
 
                 // allPartnersCounter: 0,
                 filteredPartnersCounter: 0,
@@ -461,7 +460,7 @@ function LVJM_pageImportVideos() {
                                 kw: kw,
                                 limit: this.data.videosLimit,
                                 method: method,
-                                multi_category_search: this.selectedPartnerCats === 'all_straight' ? 1 : 0,
+                                multi_category_search: cat_s === 'all_straight' || this.selectedCat === 'all_straight' ? 1 : 0,
                                 nonce: LVJM_import_videos.ajax.nonce,
                                 original_cat_s: cat_s.replace('&', '%%'),
                                 partner: partner,


### PR DESCRIPTION
## Summary
- remove redundant `selectedPartnerCats` state from the import videos page
- derive the multi-category search flag directly from the selected category before posting requests

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7cedcb560832491917c256c3ae7d6