### PR TITLE
Implement extended straight category search reporting

### DIFF
--- a/admin/actions/ajax-load-import-videos-data.php
+++ b/admin/actions/ajax-load-import-videos-data.php
@@ -26,14 +26,21 @@ function lvjm_load_import_videos_data() {
 			$feeds_array[] = $feed;
 		}
 	}
-	$data = array(
-		'feeds'             => $feeds_array,
-		'objectL10n'        => LVJM()->get_object_l10n(),
-		'partners'          => LVJM()->get_partners(),
-		'videosLimit'       => xbox_get_field_value( 'lvjm-options', 'search-results' ),
-		'WPCats'            => LVJM()->get_wp_cats(),
-		'autoImportEnabled' => xbox_get_field_value( 'lvjm-options', 'lvjm-enable-auto-import' ),
-	);
+        $videos_limit = xbox_get_field_value( 'lvjm-options', 'search-results' );
+        $videos_limit = absint( $videos_limit );
+        if ( $videos_limit <= 0 ) {
+                $videos_limit = 60;
+        }
+        $videos_limit = min( $videos_limit, 60 );
+
+        $data = array(
+                'feeds'             => $feeds_array,
+                'objectL10n'        => LVJM()->get_object_l10n(),
+                'partners'          => LVJM()->get_partners(),
+                'videosLimit'       => $videos_limit,
+                'WPCats'            => LVJM()->get_wp_cats(),
+                'autoImportEnabled' => xbox_get_field_value( 'lvjm-options', 'lvjm-enable-auto-import' ),
+        );
 	wp_send_json( $data );
 	wp_die();
 }

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -165,7 +165,8 @@ function lvjm_import_videos_page() {
 													<button v-show="!searchingVideos && !videosHasBeenSearched" v-on:click.prevent="searchVideos('create')" class="btn btn-info" v-bind:class="searchBtnClass" rel="tooltip" data-placement="top" v-bind:data-original-title="searchButtonTooltip"><i class="fa fa-search" aria-hidden="true"></i> <?php esc_html_e( 'Search videos', 'lvjm_lang' ); ?></button>
 													<button v-show="searchingVideos" disabled="disabled" class="btn btn-info"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> <?php esc_html_e( 'Searching videos...', 'lvjm_lang' ); ?></button>
 													<?php /* translators: %s: number of videos in the search results */ ?>
-													<small><i class="fa fa-info-circle" aria-hidden="true"></i> <?php printf( esc_html__( 'Each search displays up to %s unique videos at a time and excludes any videos already imported.', 'lvjm_lang' ), '{{data.videosLimit}}' ); ?></small>
+                                                                                                        <small><i class="fa fa-info-circle" aria-hidden="true"></i> <?php printf( esc_html__( 'Each search displays up to %s videos at a time. Already imported videos stay visible and are clearly labeled.', 'lvjm_lang' ), '{{data.videosLimit}}' ); ?></small>
+                                                                                                        <p v-if="resultMessage" class="text-info margin-top-5"><strong>{{ resultMessage }}</strong></p>
 												</div>
 											</div>
 										</div>
@@ -253,8 +254,8 @@ function lvjm_import_videos_page() {
                                                                                                         <div v-if="multiCategory.awaitingUser" class="alert alert-info margin-top-10">
                                                                                                                 <p class="margin-bottom-10">
                                                                                                                         <strong><?php esc_html_e( 'Continue searching next category?', 'lvjm_lang' ); ?></strong>
-                                                                                                                        <span v-if="multiCategory.currentCategory">
-                                                                                                                                — <?php esc_html_e( 'Found in', 'lvjm_lang' ); ?> {{ multiCategory.currentCategory }} ({{ multiCategory.lastCount }})
+                                                                                                                        <span v-if="multiCategory.message">
+    — {{ multiCategory.message }}
                                                                                                                         </span>
                                                                                                                 </p>
                                                                                                                 <button class="btn btn-primary" v-on:click.prevent="continueMultiCategorySearch"><?php esc_html_e( 'Yes', 'lvjm_lang' ); ?></button>
@@ -276,7 +277,7 @@ function lvjm_import_videos_page() {
 												<div id="videos" class="row" v-bind:class="displayType">
 													<template v-if="displayType == 'cards'">
 														<div v-for="(video, index) in videos" class="col-xs-12 col-sm-6 col-md-3 col-lg-2 item-cards" v-bind:key="video.id">
-															<div class="video" v-bind:class="{'grabbed': video.grabbed, 'checked': video.checked}" >
+                                                                                                                        <div class="video" v-bind:class="{'grabbed': video.grabbed, 'checked': video.checked}" >
 																<div class="video-img" v-on:click.prevent="setCurrentVideo(video, index)">
 																	<img class="img-responsive" src="<?php echo esc_html( LVJM_URL ); ?>admin/assets/img/loading-thumb.gif" v-img="video.thumb_url" data-toggle="modal" data-target="#video-preview-modal" v-bind:alt="video.title" />
 																	<div class="video-data" data-toggle="modal" data-target="#video-preview-modal">
@@ -285,7 +286,10 @@ function lvjm_import_videos_page() {
 																		<span v-if="video.trailer_url != ''" class="video-has-trailer"> <small><i class="fa fa-file-video-o" aria-hidden="true"></i> 1</small></span>
 																	</div>
 																</div>
-																<h4>{{video.title}}</h4>
+                                                                                                                               <h4>
+                                                                                                                                        {{video.title}}
+                                                                                                                                        <small v-if="video.already_imported" class="text-muted already-imported-label">(<?php esc_html_e( 'Already Imported', 'lvjm_lang' ); ?>)</small>
+                                                                                                                               </h4>
 																<div class="text-center" v-if="!video.grabbed">
 																	<div class="btn-group">
 																		<div class="btn-group">
@@ -301,7 +305,7 @@ function lvjm_import_videos_page() {
 																		<i class="fa text-danger" v-bind:class="[video.loading.removing ? 'fa-spinner fa-pulse' : 'fa-trash']" aria-hidden="true"></i>
 																	</button>
 																</div>
-																<button v-else class="btn text-center btn-block disabled"><?php esc_html_e( 'Video imported', 'lvjm_lang' ); ?></button>
+                                                                                                                               <button v-else class="btn text-center btn-block disabled">(<?php esc_html_e( 'Already Imported', 'lvjm_lang' ); ?>)</button>
 															</div>
 														</div>
 													</template>
@@ -327,7 +331,7 @@ function lvjm_import_videos_page() {
 																			<img v-else width="100"  src="<?php echo 'lvjm_lang'; ?>admin/assets/img/loading-thumb.gif" v-img="video.thumb_url" v-bind:alt="video.title" />
 																		</td>
 																		<template v-if="video.grabbed">
-																			<td colspan="3" class="video-td-imported"><?php esc_html_e( 'Video imported', 'lvjm_lang' ); ?></td>
+                                                                                                                               <td colspan="3" class="video-td-imported">(<?php esc_html_e( 'Already Imported', 'lvjm_lang' ); ?>)</td>
 																		</template>
 																		<template v-else>
 																			<td>


### PR DESCRIPTION
## Summary
- enforce a 60 video cap per request while returning and tagging already-imported results in straight category searches, and log every category count
- surface category result messages to the UI, label imported items, and prevent re-selection in the import screen
- clamp the configured search limit to 60 when loading admin data

## Testing
- php -l admin/actions/ajax-load-import-videos-data.php
- php -l admin/actions/ajax-search-videos.php
- php -l admin/class/class-lvjm-search-videos.php
- php -l admin/pages/page-import-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68d7de193434832484a627009f6877e1