### PR TITLE
Resolve partner credential key casing

### DIFF
--- a/admin/actions/ajax-get-embed-and-actors.php
+++ b/admin/actions/ajax-get-embed-and-actors.php
@@ -44,8 +44,13 @@ function lvjm_get_embed_and_actors( $params = '' ) {
         }
 
         $saved_partner_options = WPSCORE()->get_product_option( 'LVJM', 'livejasmin_options' );
-        $psid                  = isset( $saved_partner_options['psid'] ) ? sanitize_text_field( (string) $saved_partner_options['psid'] ) : '';
-        $access_key            = isset( $saved_partner_options['accesskey'] ) ? sanitize_text_field( (string) $saved_partner_options['accesskey'] ) : '';
+        $saved_partner_options = is_array( $saved_partner_options ) ? $saved_partner_options : array();
+
+        $psid_data       = lvjm_resolve_partner_credential( $saved_partner_options, 'psid', 'PSID', 'PSID' );
+        $access_key_data = lvjm_resolve_partner_credential( $saved_partner_options, 'accesskey', 'accessKey', 'Access Key' );
+
+        $psid       = $psid_data['value'];
+        $access_key = $access_key_data['value'];
         $primary_color         = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'primary-color' ) );
         $label_color           = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'label-color' ) );
         $client_ip             = '90.90.90.90';

--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -451,8 +451,23 @@ class LVJM_Search_Videos {
 	 */
         private function get_partner_feed_infos( $partner_feed_item ) {
                 $saved_partner_options = WPSCORE()->get_product_option( 'LVJM', $this->params['partner']['id'] . '_options' );
-                $context               = array(
-                        'partner_options' => is_array( $saved_partner_options ) ? $saved_partner_options : array(),
+                $saved_partner_options = is_array( $saved_partner_options ) ? $saved_partner_options : array();
+
+                $psid_data       = lvjm_resolve_partner_credential( $saved_partner_options, 'psid', 'PSID', 'PSID' );
+                $access_key_data = lvjm_resolve_partner_credential( $saved_partner_options, 'accesskey', 'accessKey', 'Access Key' );
+
+                if ( '' !== $psid_data['value'] ) {
+                        $saved_partner_options['psid'] = $psid_data['value'];
+                        $saved_partner_options['PSID'] = $psid_data['value'];
+                }
+
+                if ( '' !== $access_key_data['value'] ) {
+                        $saved_partner_options['accesskey'] = $access_key_data['value'];
+                        $saved_partner_options['accessKey'] = $access_key_data['value'];
+                }
+
+                $context = array(
+                        'partner_options' => $saved_partner_options,
                         'params'          => $this->params,
                 );
 

--- a/wps-livejasmin.php
+++ b/wps-livejasmin.php
@@ -732,6 +732,52 @@ if ( ! function_exists( 'lvjm_recursive_sanitize_text_field' ) ) {
         }
 }
 
+if ( ! function_exists( 'lvjm_resolve_partner_credential' ) ) {
+        /**
+         * Resolve a partner credential from saved options supporting multiple key formats.
+         *
+         * @param array  $options     Partner options as stored in the database.
+         * @param string $lower_key   Lowercase option key (e.g. psid, accesskey).
+         * @param string $camel_key   CamelCase option key (e.g. PSID, accessKey).
+         * @param string $label       Human readable credential label for logging.
+         *
+         * @return array{
+         *     value: string,
+         *     key: string
+         * }
+         */
+        function lvjm_resolve_partner_credential( $options, $lower_key, $camel_key, $label ) {
+                $value    = '';
+                $key_used = '';
+
+                if ( isset( $options[ $lower_key ] ) && '' !== $options[ $lower_key ] ) {
+                        $value    = $options[ $lower_key ];
+                        $key_used = $lower_key;
+                } elseif ( isset( $options[ $camel_key ] ) && '' !== $options[ $camel_key ] ) {
+                        $value    = $options[ $camel_key ];
+                        $key_used = $camel_key;
+                }
+
+                $value = '' !== $value ? sanitize_text_field( (string) $value ) : '';
+
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        error_log(
+                                sprintf(
+                                        '[WPS-LiveJasmin] Resolved %1$s using key "%2$s": %3$s',
+                                        $label,
+                                        '' !== $key_used ? $key_used : 'none',
+                                        '' !== $value ? $value : '(empty)'
+                                )
+                        );
+                }
+
+                return array(
+                        'value' => $value,
+                        'key'   => $key_used,
+                );
+        }
+}
+
 if ( ! function_exists( 'lvjm_normalize_category_slug' ) ) {
         /**
          * Normalize a partner category identifier to a slug compatible with the API/cache.


### PR DESCRIPTION
## Summary
- add a shared helper to resolve partner credential options with support for lowercase and camelCase keys
- normalize the PSID and access key values before building feed URLs in the search videos class
- load sanitized PSID and access key values in the embed/actors AJAX handler so camelCase keys work

## Testing
- php -l admin/actions/ajax-get-embed-and-actors.php
- php -l admin/class/class-lvjm-search-videos.php
- php -l wps-livejasmin.php

------
https://chatgpt.com/codex/tasks/task_e_68d8307573808324b8235d3eb4662cc9