### PR TITLE
Fix performer search parameter

### DIFF
--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -186,15 +186,14 @@ class LVJM_Search_Videos {
                                                 'labelColor'        => 'FFFFFF',
                                         );
 
+                                        // Append performer filter if provided.
+                                        if ( isset( $this->params['performer'] ) && ! empty( $this->params['performer'] ) ) {
+                                                $params['forcedPerformers'] = trim( $this->params['performer'] );
+                                        }
+
                                         $this->feed_url = $base_url . '?' . http_build_query( $params );
 
                                         error_log( '[WPS-LiveJasmin] Final hard-coded feed URL: ' . $this->feed_url );
-
-                                        // Append performer filter if provided.
-                                        if ( isset( $this->params['performer'] ) && ! empty( $this->params['performer'] ) ) {
-                                                $name             = urlencode( $this->params['performer'] );
-                                                $this->feed_url .= '&forcedPerformers[]=' . $name;
-                                        }
 
 					if ( ! $this->feed_url ) {
 						WPSCORE()->write_log( 'error', 'Connection to Partner\'s API failed (feed url: <code>' . $this->feed_url . '</code> partner id: <code>:' . $this->params['partner']['id'] . '</code>)', __FILE__, __LINE__ );


### PR DESCRIPTION
## Summary
- include the performer filter directly in the LiveJasmin list query parameters so performer lookups return matches
- rebuild the feed URL after adding the performer filter to avoid malformed forcedPerformers array parameters

## Testing
- php -l admin/class/class-lvjm-search-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68d8442a931883248af1fec8e81eeba4