### PR TITLE
Resolve client IP for LiveJasmin API requests

### DIFF
--- a/admin/actions/ajax-get-embed-and-actors.php
+++ b/admin/actions/ajax-get-embed-and-actors.php
@@ -48,7 +48,8 @@ function lvjm_get_embed_and_actors( $params = '' ) {
         $access_key            = isset( $saved_partner_options['accesskey'] ) ? sanitize_text_field( (string) $saved_partner_options['accesskey'] ) : '';
         $primary_color         = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'primary-color' ) );
         $label_color           = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'label-color' ) );
-        $client_ip             = '90.90.90.90';
+        $client_ip             = lvjm_get_client_ip_address();
+        error_log( '[WPS-LiveJasmin] Using client IP for embed details request: ' . $client_ip );
         $api_url               = 'https://pt.ptawe.com/api/video-promotion/v1/details/' . $params['video_id'] . '?clientIp=' . $client_ip . '&primaryColor=' . $primary_color . '&labelColor=' . $label_color . '&psid=' . $psid . '&accessKey=' . $access_key;
         $args                  = array(
                 'timeout'   => 300,

--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -172,13 +172,15 @@ class LVJM_Search_Videos {
                                                 return;
                                         }
 
-                                        $base_url = 'https://pt.ptawe.com/api/video-promotion/v1/list';
-                                        $params   = array(
+                                        $base_url  = 'https://pt.ptawe.com/api/video-promotion/v1/list';
+                                        $client_ip = lvjm_get_client_ip_address();
+                                        error_log( '[WPS-LiveJasmin] Using client IP for video search feed: ' . $client_ip );
+                                        $params    = array(
                                                 'site'              => 'wl3',
                                                 'tags'              => isset( $this->params['cat_s'] ) ? urlencode( $this->params['cat_s'] ) : '',
                                                 'sexualOrientation' => 'straight',
                                                 'language'          => 'en',
-                                                'clientIp'          => '127.0.0.1',
+                                                'clientIp'          => $client_ip,
                                                 'limit'             => 120,
                                                 'psid'              => $psid,
                                                 'accessKey'         => $access_key,

--- a/wps-livejasmin.php
+++ b/wps-livejasmin.php
@@ -732,6 +732,51 @@ if ( ! function_exists( 'lvjm_recursive_sanitize_text_field' ) ) {
         }
 }
 
+if ( ! function_exists( 'lvjm_get_client_ip_address' ) ) {
+        /**
+         * Resolve the most accurate client IP address available for the request.
+         *
+         * Checks common proxy headers before falling back to REMOTE_ADDR. When no
+         * valid IP can be determined, a safe localhost value is returned so API
+         * requests always receive a value.
+         *
+         * @return string
+         */
+        function lvjm_get_client_ip_address() {
+                $default     = '127.0.0.1';
+                $server_keys = array(
+                        'HTTP_CLIENT_IP',
+                        'HTTP_X_FORWARDED_FOR',
+                        'HTTP_X_FORWARDED',
+                        'HTTP_X_CLUSTER_CLIENT_IP',
+                        'HTTP_FORWARDED_FOR',
+                        'HTTP_FORWARDED',
+                        'REMOTE_ADDR',
+                );
+
+                foreach ( $server_keys as $key ) {
+                        if ( empty( $_SERVER[ $key ] ) ) {
+                                continue;
+                        }
+
+                        $raw_ips = explode( ',', (string) $_SERVER[ $key ] );
+                        foreach ( $raw_ips as $ip ) {
+                                $ip = trim( $ip );
+                                if ( '' === $ip ) {
+                                        continue;
+                                }
+
+                                $sanitized_ip = sanitize_text_field( $ip );
+                                if ( filter_var( $sanitized_ip, FILTER_VALIDATE_IP ) ) {
+                                        return $sanitized_ip;
+                                }
+                        }
+                }
+
+                return $default;
+        }
+}
+
 if ( ! function_exists( 'lvjm_normalize_category_slug' ) ) {
         /**
          * Normalize a partner category identifier to a slug compatible with the API/cache.


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the visitor IP from common proxy headers with a safe fallback
- use the resolved IP for video search and embed API calls and log the value for debugging

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d84969de6483248416c8eb5f11bbde