### PR TITLE
Handle missing AWEmpire credential errors

### DIFF
--- a/admin/actions/ajax-search-videos.php
+++ b/admin/actions/ajax-search-videos.php
@@ -48,7 +48,11 @@ function lvjm_search_videos( $params = '' ) {
             if ( false === $new_videos ) {
                 $search_videos = new LVJM_Search_Videos( $loop_params );
                 if ( $search_videos->has_errors() ) {
-                    $errors     = array_merge( $errors, (array) $search_videos->get_errors() );
+                    $search_errors = (array) $search_videos->get_errors();
+                    if ( isset( $search_errors['code'] ) || isset( $search_errors['message'] ) || isset( $search_errors['solution'] ) ) {
+                        $search_errors = array( $search_errors );
+                    }
+                    $errors     = array_merge( $errors, $search_errors );
                     $new_videos = array();
                     wp_cache_set( $cache_key, $new_videos, $cache_group, MINUTE_IN_SECONDS );
                 } else {
@@ -85,7 +89,11 @@ function lvjm_search_videos( $params = '' ) {
     } else {
         $search_videos = new LVJM_Search_Videos( $params );
         if ( $search_videos->has_errors() ) {
-            $errors = (array) $search_videos->get_errors();
+            $search_errors = (array) $search_videos->get_errors();
+            if ( isset( $search_errors['code'] ) || isset( $search_errors['message'] ) || isset( $search_errors['solution'] ) ) {
+                $search_errors = array( $search_errors );
+            }
+            $errors = $search_errors;
         } else {
             $videos = (array) $search_videos->get_videos();
             $searched_data = $search_videos->get_searched_data();

--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -105,7 +105,8 @@ class LVJM_Search_Videos {
         }
                 global $wp_version;
                 $this->wp_version = $wp_version;
-                $this->params     = $params;
+               $this->params     = $params;
+               $this->errors     = array();
 
                 // connecting to API.
                 $api_params = array(
@@ -167,10 +168,16 @@ class LVJM_Search_Videos {
                                                 $access_key = sanitize_text_field( (string) get_option( 'wps_lj_accesskey' ) );
                                         }
 
-                                        if ( empty( $psid ) || empty( $access_key ) ) {
-                                                error_log( '[WPS-LiveJasmin ERROR] Missing PSID or AccessKey – cannot build feed URL.' );
-                                                return;
-                                        }
+                                       if ( empty( $psid ) || empty( $access_key ) ) {
+                                               error_log( '[WPS-LiveJasmin ERROR] Missing PSID or AccessKey – cannot build feed URL.' );
+                                               $this->errors = array(
+                                                       'code'     => 'missing_credentials',
+                                                       'message'  => __( 'Your AWEmpire PSID or Access Key is missing.', 'wps-livejasmin' ),
+                                                       'solution' => __( 'Please add both credentials in the LiveJasmin settings.', 'wps-livejasmin' ),
+                                               );
+
+                                               return false;
+                                       }
 
                                         $base_url = 'https://pt.ptawe.com/api/video-promotion/v1/list';
                                         $params   = array(


### PR DESCRIPTION
## Summary
- populate a structured error when the LiveJasmin PSID or Access Key is missing
- surface credential errors in the AJAX search response so the Vue UI can display them

## Testing
- php -l admin/class/class-lvjm-search-videos.php
- php -l admin/actions/ajax-search-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68d8496d45708324bbc8fb127800f4c9