### PR TITLE
Fix double encoding of category tags in video search

### DIFF
--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -184,7 +184,7 @@ class LVJM_Search_Videos {
                                         error_log( '[WPS-LiveJasmin] Using client IP for video search feed: ' . $client_ip );
                                         $params    = array(
                                                 'site'              => 'wl3',
-                                                'tags'              => isset( $this->params['cat_s'] ) ? urlencode( $this->params['cat_s'] ) : '',
+                                                'tags'              => isset( $this->params['cat_s'] ) ? $this->params['cat_s'] : '',
                                                 'sexualOrientation' => 'straight',
                                                 'language'          => 'en',
                                                 'clientIp'          => $client_ip,


### PR DESCRIPTION
## Summary
- pass the raw category tag value to http_build_query when constructing the video feed URL
- rely on http_build_query for encoding so category names with spaces are handled correctly

## Testing
- php -r '$params=["site"=>"wl3","tags"=>"Hot Moms","forcedPerformers"=>"Jane Doe"]; echo http_build_query($params),"\n";'


------
https://chatgpt.com/codex/tasks/task_e_68d983733f0883249684b2d72f9af6d0