### PR TITLE
Normalize performer queries before searches

### DIFF
--- a/admin/actions/ajax-search-videos.php
+++ b/admin/actions/ajax-search-videos.php
@@ -25,7 +25,9 @@ function lvjm_search_videos( $params = '' ) {
     $videos         = array();
     $seen_ids       = array();
     $searched_data  = array();
-    $performer      = isset( $params['performer'] ) ? sanitize_text_field( (string) $params['performer'] ) : '';
+    $performer_raw  = isset( $params['performer'] ) ? sanitize_text_field( (string) $params['performer'] ) : '';
+    $performer      = lvjm_normalize_performer_query( $performer_raw );
+    $params['performer'] = $performer;
     $is_multi  = isset( $params['multi_category_search'] ) && '1' === (string) $params['multi_category_search'];
 
     if ( $is_multi ) {

--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -3,6 +3,34 @@ _.contains = _.includes;
 window.lodash = _.noConflict();
 window.addEventListener('load', LVJM_pageImportVideos, false);
 
+function lvjmNormalizePerformerQuery(input) {
+    if (typeof input !== 'string') {
+        return '';
+    }
+
+    var sanitized = input;
+    try {
+        sanitized = sanitized.replace(/[^\p{L}\p{N}\s]+/gu, ' ');
+    } catch (error) {
+        sanitized = sanitized.replace(/[^A-Za-z0-9\s]+/g, ' ');
+    }
+
+    sanitized = sanitized.replace(/_/g, ' ').trim();
+
+    if (sanitized === '') {
+        return '';
+    }
+
+    return sanitized.split(/\s+/).map(function (word) {
+        if (!word) {
+            return '';
+        }
+
+        var lower = word.toLowerCase();
+        return lower.charAt(0).toUpperCase() + lower.slice(1);
+    }).join('');
+}
+
 function LVJM_pageImportVideos() {
 
     if (document.getElementById('import-videos')) {
@@ -495,6 +523,8 @@ function LVJM_pageImportVideos() {
                     this.searchingVideos = true;
 
                     var requestCat = category.id;
+                    var normalizedPerformer = lvjmNormalizePerformerQuery(this.selectedPerformer);
+
                     var payload = {
                         action: 'lvjm_search_videos',
                         cat_s: requestCat,
@@ -507,7 +537,7 @@ function LVJM_pageImportVideos() {
                         nonce: LVJM_import_videos.ajax.nonce,
                         original_cat_s: requestCat ? requestCat.replace('&', '%%') : '',
                         partner: this.performerSearchPartner,
-                        performer: this.selectedPerformer
+                        performer: normalizedPerformer
                     };
 
                     this.$http.post(
@@ -578,6 +608,8 @@ function LVJM_pageImportVideos() {
                     this.performerFallbackRan = true;
                     this.searchingVideos = true;
 
+                    var normalizedPerformer = lvjmNormalizePerformerQuery(this.selectedPerformer);
+
                     this.$http.post(
                         LVJM_import_videos.ajax.url,
                         {
@@ -592,7 +624,7 @@ function LVJM_pageImportVideos() {
                             nonce: LVJM_import_videos.ajax.nonce,
                             original_cat_s: '',
                             partner: this.performerSearchPartner,
-                            performer: this.selectedPerformer
+                            performer: normalizedPerformer
                         },
                         { emulateJSON: true }
                     ).then(function (response) {
@@ -770,7 +802,9 @@ function LVJM_pageImportVideos() {
                         return;
                     }
 
-                    if (this.selectedPerformer && this.selectedPerformer.trim() !== '') {
+                    var normalizedPerformer = lvjmNormalizePerformerQuery(this.selectedPerformer);
+
+                    if (normalizedPerformer !== '') {
                         this.startPerformerSearch({ mode: 'performer' });
                         return;
                     }
@@ -789,7 +823,7 @@ function LVJM_pageImportVideos() {
                                 nonce: LVJM_import_videos.ajax.nonce,
                                 original_cat_s: cat_s.replace('&', '%%'),
                                 partner: partner,
-                                performer: this.selectedPerformer
+                                performer: normalizedPerformer
                             }, {
                                 emulateJSON: true
                             })

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -151,8 +151,8 @@ function lvjm_import_videos_page() {
 															</span>
 											<span id="performer-search" style="margin-left:8px;">
 												<label for="performer_s" class="sr-only"><?php esc_html_e( 'Performer', 'lvjm_lang' ); ?></label>
-												<input type="text" v-model="selectedPerformer" placeholder="<?php esc_attr_e( 'Performer (optional)', 'lvjm_lang' ); ?>" id="performer_s" name="performer_s" class="form-control" style="width:220px;">
-											</span>
+                                                                                                <input type="text" v-model="selectedPerformer" placeholder="<?php esc_attr_e( 'Performer (e.g., First Last)', 'lvjm_lang' ); ?>" id="performer_s" name="performer_s" class="form-control" style="width:220px;">
+                                                                                        </span>
 
 														</div>
 													</div>

--- a/wps-livejasmin.php
+++ b/wps-livejasmin.php
@@ -777,6 +777,42 @@ if ( ! function_exists( 'lvjm_get_client_ip_address' ) ) {
         }
 }
 
+if ( ! function_exists( 'lvjm_normalize_performer_query' ) ) {
+        /**
+         * Convert a performer name into the camel-cased LiveJasmin identifier.
+         *
+         * @param string $performer Performer name entered by an editor or CLI task.
+         * @return string Normalized performer identifier.
+         */
+        function lvjm_normalize_performer_query( $performer ) {
+                $performer = (string) $performer;
+                $performer = preg_replace( '/[^\p{L}\p{N}\s]+/u', ' ', $performer );
+                $performer = trim( $performer );
+
+                if ( '' === $performer ) {
+                        return '';
+                }
+
+                $words       = preg_split( '/\s+/u', $performer );
+                $normalized  = array();
+
+                foreach ( (array) $words as $word ) {
+                        $word = trim( $word );
+                        if ( '' === $word ) {
+                                continue;
+                        }
+
+                        if ( function_exists( 'mb_convert_case' ) ) {
+                                $normalized[] = mb_convert_case( $word, MB_CASE_TITLE, 'UTF-8' );
+                        } else {
+                                $normalized[] = ucfirst( strtolower( $word ) );
+                        }
+                }
+
+                return implode( '', $normalized );
+        }
+}
+
 if ( ! function_exists( 'lvjm_normalize_category_slug' ) ) {
         /**
          * Normalize a partner category identifier to a slug compatible with the API/cache.


### PR DESCRIPTION
## Summary
- add a shared lvjm_normalize_performer_query helper for camel-casing performer IDs
- send normalized performer identifiers from admin UI and server-side searches
- clarify the performer field placeholder to highlight spaced name support

## Testing
- php -l wps-livejasmin.php
- php -l admin/actions/ajax-search-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68d9986104a48324bac4a0d22009c263