### PR TITLE
Preserve performer token casing after first character

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -26,8 +26,14 @@ function lvjmNormalizePerformerQuery(input) {
             return '';
         }
 
-        var lower = word.toLowerCase();
-        return lower.charAt(0).toUpperCase() + lower.slice(1);
+        var characters = Array.from(word);
+        var firstChar = characters.shift();
+
+        if (typeof firstChar === 'undefined') {
+            return '';
+        }
+
+        return firstChar.toLocaleUpperCase() + characters.join('');
     }).join('');
 }
 

--- a/wps-livejasmin.php
+++ b/wps-livejasmin.php
@@ -802,10 +802,23 @@ if ( ! function_exists( 'lvjm_normalize_performer_query' ) ) {
                                 continue;
                         }
 
-                        if ( function_exists( 'mb_convert_case' ) ) {
-                                $normalized[] = mb_convert_case( $word, MB_CASE_TITLE, 'UTF-8' );
+                        if ( function_exists( 'mb_substr' ) && function_exists( 'mb_strtoupper' ) ) {
+                                $first_char = mb_substr( $word, 0, 1, 'UTF-8' );
+                                $rest       = mb_substr( $word, 1, null, 'UTF-8' );
+
+                                if ( false === $first_char ) {
+                                        $first_char = '';
+                                }
+
+                                if ( false === $rest ) {
+                                        $rest = '';
+                                }
+
+                                $normalized[] = mb_strtoupper( $first_char, 'UTF-8' ) . $rest;
                         } else {
-                                $normalized[] = ucfirst( strtolower( $word ) );
+                                $first_char   = substr( $word, 0, 1 );
+                                $rest         = substr( $word, 1 );
+                                $normalized[] = strtoupper( $first_char ) . $rest;
                         }
                 }
 


### PR DESCRIPTION
## Summary
- update the admin performer normalization to uppercase only the first character of each token while leaving the remainder untouched
- align the PHP normalization helper with the same casing logic using multibyte-safe string functions so all entry points behave identically

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d99e7856408324a859e021c28f4f26