### PR TITLE
Propagate orientation metadata through partner categories

### DIFF
--- a/admin/actions/ajax-load-partner-cats.php
+++ b/admin/actions/ajax-load-partner-cats.php
@@ -41,25 +41,30 @@ function lvjm_load_partner_cats() {
 	$output = array();
 	$i      = 0;
 
-	foreach ( (array) $partner_categories as $partner_category ) {
-		$output[ $i ] = $partner_category;
-		if ( 'optgroup' === $partner_category['id'] ) {
-			foreach ( $partner_category['sub_cats'] as $index => $partner_sub_cat ) {
-				$output[ $i ]['sub_cats'][ $index ]['disabled'] = in_array( $partner_sub_cat['id'], $cats_used, true );
-			}
-		} else {
-			$output[ $i ]['disabled'] = in_array( $partner_category['id'], $cats_used, true );
-		}
-		++$i;
-	}
-	// Inject custom category
-if (is_array($output) && isset($output[0]['id'])) {
-    array_unshift($output, array(
-        'id' => 'all_straight',
-        'name' => 'All Straight Categories'
-    ));
-}
-wp_send_json( $output );
+        foreach ( (array) $partner_categories as $partner_category ) {
+                $output[ $i ] = $partner_category;
+                if ( 'optgroup' === $partner_category['id'] ) {
+                        foreach ( $partner_category['sub_cats'] as $index => $partner_sub_cat ) {
+                                $output[ $i ]['sub_cats'][ $index ]['disabled'] = in_array( $partner_sub_cat['id'], $cats_used, true );
+                        }
+                } else {
+                        $output[ $i ]['disabled'] = in_array( $partner_category['id'], $cats_used, true );
+                }
+                ++$i;
+        }
+
+        // Inject custom category.
+        if ( is_array( $output ) && isset( $output[0]['id'] ) ) {
+                array_unshift(
+                        $output,
+                        array(
+                                'id'          => 'all_straight',
+                                'name'        => 'All Straight Categories',
+                                'orientation' => 'straight',
+                        )
+                );
+        }
+        wp_send_json( $output );
 	wp_die();
 }
 add_action( 'wp_ajax_lvjm_load_partner_cats', 'lvjm_load_partner_cats' );

--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -443,33 +443,39 @@ function LVJM_pageImportVideos() {
                     options = options || {};
                     var onlyStraight = !!options.onlyStraight;
                     var categories = [];
-                    var isStraight = function (item) {
+                    var targetOrientation = 'straight';
+                    var getOrientation = function (item) {
                         if (!item) {
-                            return false;
+                            return '';
                         }
-                        var label = (item.name || '').toString().toLowerCase();
-                        var identifier = (item.id || '').toString().toLowerCase();
-                        return label.indexOf('straight') !== -1 || identifier.indexOf('straight') !== -1;
+                        var orientation = item.orientation || '';
+                        return orientation.toString().toLowerCase();
                     };
 
                     lodash.each(this.partnerCats, function (cat) {
+                        if (!cat || !cat.id) {
+                            return;
+                        }
+
+                        var catOrientation = getOrientation(cat);
+
                         if (cat.id === 'optgroup' && cat.sub_cats) {
-                            var groupIsStraight = !onlyStraight || isStraight(cat);
-                            if (!groupIsStraight) {
+                            if (onlyStraight && catOrientation !== targetOrientation) {
                                 return;
                             }
 
                             lodash.each(cat.sub_cats, function (sub) {
-                                if (!sub.id || sub.id === 'all_straight') {
+                                if (!sub || !sub.id || sub.id === 'all_straight') {
                                     return;
                                 }
 
-                                if (!onlyStraight || groupIsStraight || isStraight(sub)) {
+                                var subOrientation = getOrientation(sub) || catOrientation;
+                                if (!onlyStraight || subOrientation === targetOrientation) {
                                     categories.push({ id: sub.id, name: sub.name });
                                 }
                             });
-                        } else if (cat.id && cat.id !== 'optgroup' && cat.id !== 'all_straight') {
-                            if (!onlyStraight || isStraight(cat)) {
+                        } else if (cat.id !== 'all_straight') {
+                            if (!onlyStraight || catOrientation === targetOrientation) {
                                 categories.push({ id: cat.id, name: cat.name });
                             }
                         }

--- a/wps-livejasmin.php
+++ b/wps-livejasmin.php
@@ -411,24 +411,28 @@ public function get_whitelabel_id_from_url( $url ) {
 		private function order_categories( $categories ) {
 			$ordered_cats = array();
 			$i            = 0;
-			foreach ( $categories as $cat_id => $cat_name ) {
-				if ( strpos( $cat_id, 'optgroup' ) !== false ) {
-					$cat_id_explode     = explode( '::', $cat_id );
-					$ordered_cats[ $i ] = array(
-						'id'   => 'optgroup',
-						'name' => end( $cat_id_explode ),
-					);
-					foreach ( (array) $cat_name as $sub_cat_id => $sub_cat_name ) {
-						$ordered_cats[ $i ]['sub_cats'][] = array(
-							'id'   => $sub_cat_id,
-							'name' => $sub_cat_name,
-						);
-					}
-				} else {
-					$ordered_cats[ $i ] = array(
-						'id'   => $cat_id,
-						'name' => $cat_name,
-					);
+                        foreach ( $categories as $cat_id => $cat_name ) {
+                                if ( strpos( $cat_id, 'optgroup' ) !== false ) {
+                                        $cat_id_explode         = explode( '::', $cat_id );
+                                        $orientation_label      = end( $cat_id_explode );
+                                        $orientation_identifier = strtolower( $orientation_label );
+                                        $ordered_cats[ $i ]     = array(
+                                                'id'          => 'optgroup',
+                                                'name'        => $orientation_label,
+                                                'orientation' => $orientation_identifier,
+                                        );
+                                        foreach ( (array) $cat_name as $sub_cat_id => $sub_cat_name ) {
+                                                $ordered_cats[ $i ]['sub_cats'][] = array(
+                                                        'id'          => $sub_cat_id,
+                                                        'name'        => $sub_cat_name,
+                                                        'orientation' => $orientation_identifier,
+                                                );
+                                        }
+                                } else {
+                                        $ordered_cats[ $i ] = array(
+                                                'id'   => $cat_id,
+                                                'name' => $cat_name,
+                                        );
 				}
 				++$i;
 			}


### PR DESCRIPTION
## Summary
- add stable orientation identifiers to partner category optgroups and their children
- expose the orientation metadata in the AJAX payload, including the synthetic all-straight option
- update the performer category filter to rely on the orientation field instead of localized strings

## Testing
- php -l wps-livejasmin.php
- php -l admin/actions/ajax-load-partner-cats.php

------
https://chatgpt.com/codex/tasks/task_e_68d9a648e9ac8324b38d46f2334afeef