### PR TITLE
Show active category while running performer searches

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -143,6 +143,10 @@ function LVJM_pageImportVideos() {
                 performerSearchFeedId: '',
                 performerFallbackRan: false,
                 performerSearchMode: '',
+                currentSearchCategoryId: '',
+                currentSearchCategoryLabel: '',
+                currentSearchCategoryIndex: 0,
+                currentSearchCategoryTotal: 0,
                 selectedWPCat: 0,
                 selectedPostsStatus: '',
                 newWpCategoryName: '',
@@ -490,6 +494,10 @@ function LVJM_pageImportVideos() {
                     var onlyStraight = this.performerSearchMode === 'all_straight';
                     var categories = this.flattenPartnerCategories({ onlyStraight: onlyStraight });
 
+                    this.currentSearchCategoryId = '';
+                    this.currentSearchCategoryLabel = '';
+                    this.currentSearchCategoryIndex = 0;
+
                     if (this.selectedCat && this.selectedCat !== 'all_straight') {
                         var prioritizedCategory = null;
                         lodash.each(categories, function (category) {
@@ -504,6 +512,7 @@ function LVJM_pageImportVideos() {
                     }
 
                     this.performerCategoryQueue = categories;
+                    this.currentSearchCategoryTotal = this.performerCategoryQueue.length;
                     this.performerSearchIndex = 0;
                     this.performerSeenIds = {};
                     this.performerSearchActive = true;
@@ -531,6 +540,10 @@ function LVJM_pageImportVideos() {
                     }
 
                     var category = this.performerCategoryQueue[this.performerSearchIndex];
+                    this.currentSearchCategoryId = category.id || '';
+                    this.currentSearchCategoryLabel = category.name || '';
+                    this.currentSearchCategoryIndex = this.performerSearchIndex;
+                    this.currentSearchCategoryTotal = this.performerCategoryQueue.length;
                     this.performerSearchIndex++;
                     this.searchingVideos = true;
 
@@ -662,6 +675,10 @@ function LVJM_pageImportVideos() {
                     this.searchingVideos = false;
                     this.videosHasBeenSearched = true;
                     this.performerSearchMode = '';
+                    this.currentSearchCategoryId = '';
+                    this.currentSearchCategoryLabel = '';
+                    this.currentSearchCategoryIndex = 0;
+                    this.currentSearchCategoryTotal = 0;
                     jQuery('[data-id="sort_partners"]').prop("disabled", false);
                     jQuery('[data-id="cat_s_select"]').prop("disabled", false);
                     jQuery('[data-id="partner_select"]').prop("disabled", false);
@@ -705,6 +722,10 @@ function LVJM_pageImportVideos() {
                     this.performerSeenIds = {};
                     this.performerFallbackRan = false;
                     this.performerSearchMode = '';
+                    this.currentSearchCategoryId = '';
+                    this.currentSearchCategoryLabel = '';
+                    this.currentSearchCategoryIndex = 0;
+                    this.currentSearchCategoryTotal = 0;
 
                     setTimeout(function () {
                         jQuery('#partner_select').selectpicker('refresh');
@@ -802,6 +823,10 @@ function LVJM_pageImportVideos() {
                     this.performerSearchMethod = method;
                     this.performerSearchFeedId = feedId || '';
                     this.performerFallbackRan = false;
+                    this.currentSearchCategoryId = '';
+                    this.currentSearchCategoryLabel = '';
+                    this.currentSearchCategoryIndex = 0;
+                    this.currentSearchCategoryTotal = 0;
 
                     if (method == 'create') {
                         this.firstImport = true;

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -163,8 +163,15 @@ function lvjm_import_videos_page() {
 														<button class="btn btn-default" disabled><i class="fa fa-check" aria-hidden="true"></i> <?php esc_html_e( 'Search done!', 'lvjm_lang' ); ?></button>
 													</span>
 													<button v-show="!searchingVideos && !videosHasBeenSearched" v-on:click.prevent="searchVideos('create')" class="btn btn-info" v-bind:class="searchBtnClass" rel="tooltip" data-placement="top" v-bind:data-original-title="searchButtonTooltip"><i class="fa fa-search" aria-hidden="true"></i> <?php esc_html_e( 'Search videos', 'lvjm_lang' ); ?></button>
-													<button v-show="searchingVideos" disabled="disabled" class="btn btn-info"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> <?php esc_html_e( 'Searching videos...', 'lvjm_lang' ); ?></button>
-													<?php /* translators: %s: number of videos in the search results */ ?>
+                                                                                                        <button v-show="searchingVideos" disabled="disabled" class="btn btn-info"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> <?php esc_html_e( 'Searching videos...', 'lvjm_lang' ); ?></button>
+                                                                                                        <p class="text-info" v-if="performerSearchActive && currentSearchCategoryLabel">
+                                                                                                                <strong><?php esc_html_e( 'Currently searching category', 'lvjm_lang' ); ?></strong>:
+                                                                                                                {{ currentSearchCategoryLabel }}
+                                                                                                                <span v-if="currentSearchCategoryTotal > 0">
+                                                                                                                        ({{ currentSearchCategoryIndex + 1 }} / {{ currentSearchCategoryTotal }})
+                                                                                                                </span>
+                                                                                                        </p>
+                                                                                                        <?php /* translators: %s: number of videos in the search results */ ?>
                                                                                                        <small><i class="fa fa-info-circle" aria-hidden="true"></i> <?php printf( esc_html__( 'Each search displays up to %s videos at a time, including previously imported ones (marked as ✅ Already Imported).', 'lvjm_lang' ), '{{data.videosLimit}}' ); ?></small>
 												</div>
 											</div>


### PR DESCRIPTION
## Summary
- track the current category details during multi-category performer searches
- surface the active category (with progress) in the Import Videos UI so admins can follow the queue

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9a15549b883248e605755cdb4dd83