### PR TITLE
Auto-advance performer search categories

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -582,22 +582,7 @@ function LVJM_pageImportVideos() {
 
                             var hasNext = self.performerSearchIndex < self.performerCategoryQueue.length;
                             if (hasNext) {
-                                if (added > 0) {
-                                    var baseMessage = 'Do you want to search the next category? (Yes/No)';
-                                    var message = 'Found ' + added + ' videos in ' + category.name + '.';
-                                    if (self.selectedPerformer && self.selectedPerformer.trim() !== '') {
-                                        message = 'Found ' + added + ' videos in ' + category.name + ' for performer ' + self.selectedPerformer + '.';
-                                    }
-                                    message += ' ' + baseMessage;
-
-                                    if (window.confirm(message)) {
-                                        self.performerSearchNextCategory();
-                                    } else {
-                                        self.finishCategoryLoop();
-                                    }
-                                } else {
-                                    self.performerSearchNextCategory();
-                                }
+                                self.performerSearchNextCategory();
                             } else {
                                 self.finishCategoryLoop();
                             }


### PR DESCRIPTION
## Summary
- remove the confirm dialog that stopped category iteration after finding results
- let performer searches automatically advance through every category in the queue

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9aad56bec8324b6934eebdf2eb5e4