### PR TITLE
Automate performer category traversal

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -135,6 +135,7 @@ function LVJM_pageImportVideos() {
                 selectedKW: '',
                 selectedPerformer: '',
                 performerSearchActive: false,
+                performerSearchCancelled: false,
                 performerCategoryQueue: [],
                 performerSearchIndex: 0,
                 performerSeenIds: {},
@@ -143,6 +144,9 @@ function LVJM_pageImportVideos() {
                 performerSearchFeedId: '',
                 performerFallbackRan: false,
                 performerSearchMode: '',
+                performerSearchTotalFound: 0,
+                performerSearchLastAdded: 0,
+                performerSearchLastCategory: '',
                 currentSearchCategoryId: '',
                 currentSearchCategoryLabel: '',
                 currentSearchCategoryIndex: 0,
@@ -494,6 +498,10 @@ function LVJM_pageImportVideos() {
                     var onlyStraight = this.performerSearchMode === 'all_straight';
                     var categories = this.flattenPartnerCategories({ onlyStraight: onlyStraight });
 
+                    this.performerSearchTotalFound = 0;
+                    this.performerSearchLastAdded = 0;
+                    this.performerSearchLastCategory = '';
+
                     this.currentSearchCategoryId = '';
                     this.currentSearchCategoryLabel = '';
                     this.currentSearchCategoryIndex = 0;
@@ -516,6 +524,7 @@ function LVJM_pageImportVideos() {
                     this.performerSearchIndex = 0;
                     this.performerSeenIds = {};
                     this.performerSearchActive = true;
+                    this.performerSearchCancelled = false;
 
                     if (!this.performerCategoryQueue.length) {
                         if (this.performerSearchMode === 'performer') {
@@ -530,7 +539,8 @@ function LVJM_pageImportVideos() {
                 },
                 performerSearchNextCategory: function () {
                     var self = this;
-                    if (!this.performerSearchActive) {
+                    if (!this.performerSearchActive || this.performerSearchCancelled) {
+                        this.finishCategoryLoop();
                         return;
                     }
 
@@ -578,26 +588,21 @@ function LVJM_pageImportVideos() {
                                 trackSeen: true
                             });
                             self.videosHasBeenSearched = true;
-                            self.searchingVideos = false;
+
+                            self.performerSearchLastCategory = category.name || '';
+                            self.performerSearchLastAdded = added;
+                            if (added > 0) {
+                                self.performerSearchTotalFound += added;
+                            }
+
+                            if (!self.performerSearchActive || self.performerSearchCancelled) {
+                                self.finishCategoryLoop();
+                                return;
+                            }
 
                             var hasNext = self.performerSearchIndex < self.performerCategoryQueue.length;
                             if (hasNext) {
-                                if (added > 0) {
-                                    var baseMessage = 'Do you want to search the next category? (Yes/No)';
-                                    var message = 'Found ' + added + ' videos in ' + category.name + '.';
-                                    if (self.selectedPerformer && self.selectedPerformer.trim() !== '') {
-                                        message = 'Found ' + added + ' videos in ' + category.name + ' for performer ' + self.selectedPerformer + '.';
-                                    }
-                                    message += ' ' + baseMessage;
-
-                                    if (window.confirm(message)) {
-                                        self.performerSearchNextCategory();
-                                    } else {
-                                        self.finishCategoryLoop();
-                                    }
-                                } else {
-                                    self.performerSearchNextCategory();
-                                }
+                                self.performerSearchNextCategory();
                             } else {
                                 self.finishCategoryLoop();
                             }
@@ -613,6 +618,11 @@ function LVJM_pageImportVideos() {
                     });
                 },
                 finishCategoryLoop: function () {
+                    this.searchingVideos = false;
+                    if (this.performerSearchCancelled) {
+                        this.finishPerformerSearch();
+                        return;
+                    }
                     if (this.performerSearchMode === 'performer') {
                         this.runPerformerFallback();
                     } else {
@@ -655,12 +665,17 @@ function LVJM_pageImportVideos() {
                     ).then(function (response) {
                         if (lodash.isEmpty(response.body.errors)) {
                             self.searchedData = response.body.searched_data;
-                            self.appendVideosFromResponse(response.body.videos, '', {
+                            var added = self.appendVideosFromResponse(response.body.videos, '', {
                                 categoryName: 'All Categories',
                                 origin: 'fallback',
                                 trackSeen: true,
                                 onlyNew: true
                             });
+                            self.performerSearchLastCategory = 'All Categories';
+                            self.performerSearchLastAdded = added;
+                            if (added > 0) {
+                                self.performerSearchTotalFound += added;
+                            }
                         } else {
                             self.videosSearchedErrors = response.body.errors;
                         }
@@ -679,10 +694,19 @@ function LVJM_pageImportVideos() {
                     this.currentSearchCategoryLabel = '';
                     this.currentSearchCategoryIndex = 0;
                     this.currentSearchCategoryTotal = 0;
+                    this.performerSearchCancelled = false;
                     jQuery('[data-id="sort_partners"]').prop("disabled", false);
                     jQuery('[data-id="cat_s_select"]').prop("disabled", false);
                     jQuery('[data-id="partner_select"]').prop("disabled", false);
                     stickNav();
+                },
+                cancelPerformerSearch: function () {
+                    if (!this.performerSearchActive) {
+                        return;
+                    }
+
+                    this.performerSearchCancelled = true;
+                    this.performerSearchActive = false;
                 },
                 loadPartnerCats: function () {
                     this.partnerCatsLoading = true;
@@ -717,11 +741,15 @@ function LVJM_pageImportVideos() {
                     this.isTestSearch = false;
                     this.videosHasBeenSearched = false;
                     this.performerSearchActive = false;
+                    this.performerSearchCancelled = false;
                     this.performerCategoryQueue = [];
                     this.performerSearchIndex = 0;
                     this.performerSeenIds = {};
                     this.performerFallbackRan = false;
                     this.performerSearchMode = '';
+                    this.performerSearchTotalFound = 0;
+                    this.performerSearchLastAdded = 0;
+                    this.performerSearchLastCategory = '';
                     this.currentSearchCategoryId = '';
                     this.currentSearchCategoryLabel = '';
                     this.currentSearchCategoryIndex = 0;
@@ -815,6 +843,7 @@ function LVJM_pageImportVideos() {
                     //jQuery('[rel=tooltip]').tooltip('hide');
 
                     this.performerSearchActive = false;
+                    this.performerSearchCancelled = false;
                     this.performerCategoryQueue = [];
                     this.performerSearchIndex = 0;
                     this.performerSeenIds = {};
@@ -827,6 +856,9 @@ function LVJM_pageImportVideos() {
                     this.currentSearchCategoryLabel = '';
                     this.currentSearchCategoryIndex = 0;
                     this.currentSearchCategoryTotal = 0;
+                    this.performerSearchTotalFound = 0;
+                    this.performerSearchLastAdded = 0;
+                    this.performerSearchLastCategory = '';
 
                     if (method == 'create') {
                         this.firstImport = true;

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -164,6 +164,7 @@ function lvjm_import_videos_page() {
 													</span>
 													<button v-show="!searchingVideos && !videosHasBeenSearched" v-on:click.prevent="searchVideos('create')" class="btn btn-info" v-bind:class="searchBtnClass" rel="tooltip" data-placement="top" v-bind:data-original-title="searchButtonTooltip"><i class="fa fa-search" aria-hidden="true"></i> <?php esc_html_e( 'Search videos', 'lvjm_lang' ); ?></button>
                                                                                                         <button v-show="searchingVideos" disabled="disabled" class="btn btn-info"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> <?php esc_html_e( 'Searching videos...', 'lvjm_lang' ); ?></button>
+                                                                                                        <button v-show="performerSearchActive" v-on:click.prevent="cancelPerformerSearch" class="btn btn-warning" style="margin-left:5px;"><i class="fa fa-stop-circle" aria-hidden="true"></i> <?php esc_html_e( 'Stop category search', 'lvjm_lang' ); ?></button>
                                                                                                         <p class="text-info" v-if="performerSearchActive && currentSearchCategoryLabel">
                                                                                                                 <strong><?php esc_html_e( 'Currently searching category', 'lvjm_lang' ); ?></strong>:
                                                                                                                 {{ currentSearchCategoryLabel }}
@@ -171,9 +172,22 @@ function lvjm_import_videos_page() {
                                                                                                                         ({{ currentSearchCategoryIndex + 1 }} / {{ currentSearchCategoryTotal }})
                                                                                                                 </span>
                                                                                                         </p>
+                                                                                                        <p class="text-muted" v-if="performerSearchLastCategory">
+                                                                                                                <strong><?php esc_html_e( 'Latest category result', 'lvjm_lang' ); ?></strong>:
+                                                                                                                {{ performerSearchLastCategory }}
+                                                                                                                <span v-if="performerSearchLastAdded > 0">
+                                                                                                                        &ndash; <?php esc_html_e( 'Found', 'lvjm_lang' ); ?> {{ performerSearchLastAdded }} <?php esc_html_e( 'new videos', 'lvjm_lang' ); ?>
+                                                                                                                </span>
+                                                                                                                <span v-else>
+                                                                                                                        &ndash; <?php esc_html_e( 'No new videos found', 'lvjm_lang' ); ?>
+                                                                                                                </span>
+                                                                                                                <template v-if="performerSearchTotalFound > 0">
+                                                                                                                        (<?php esc_html_e( 'Total new videos so far', 'lvjm_lang' ); ?>: {{ performerSearchTotalFound }})
+                                                                                                                </template>
+                                                                                                        </p>
                                                                                                         <?php /* translators: %s: number of videos in the search results */ ?>
                                                                                                        <small><i class="fa fa-info-circle" aria-hidden="true"></i> <?php printf( esc_html__( 'Each search displays up to %s videos at a time, including previously imported ones (marked as ✅ Already Imported).', 'lvjm_lang' ), '{{data.videosLimit}}' ); ?></small>
-												</div>
+                                                                                                </div>
 											</div>
 										</div>
 									</div>


### PR DESCRIPTION
## Summary
- automatically advance performer searches through each partner category without requiring manual confirmation
- surface live progress totals for the most recent category and cumulative new videos while allowing the loop to be cancelled
- reset performer search state between manual searches and include fallback results in the totals

## Testing
- Not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68d9aad56bec8324b6934eebdf2eb5e4