### PR TITLE
Fix straight-only performer searches skipping categories

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -455,6 +455,17 @@ function LVJM_pageImportVideos() {
                         var orientation = item.orientation || '';
                         return orientation.toString().toLowerCase();
                     };
+                    var matchesOrientation = function (orientation) {
+                        if (!onlyStraight) {
+                            return true;
+                        }
+
+                        if (!orientation) {
+                            return true;
+                        }
+
+                        return orientation === targetOrientation;
+                    };
 
                     lodash.each(this.partnerCats, function (cat) {
                         if (!cat || !cat.id) {
@@ -464,7 +475,7 @@ function LVJM_pageImportVideos() {
                         var catOrientation = getOrientation(cat);
 
                         if (cat.id === 'optgroup' && cat.sub_cats) {
-                            if (onlyStraight && catOrientation !== targetOrientation) {
+                            if (!matchesOrientation(catOrientation)) {
                                 return;
                             }
 
@@ -474,12 +485,12 @@ function LVJM_pageImportVideos() {
                                 }
 
                                 var subOrientation = getOrientation(sub) || catOrientation;
-                                if (!onlyStraight || subOrientation === targetOrientation) {
+                                if (matchesOrientation(subOrientation)) {
                                     categories.push({ id: sub.id, name: sub.name });
                                 }
                             });
                         } else if (cat.id !== 'all_straight') {
-                            if (!onlyStraight || catOrientation === targetOrientation) {
+                            if (matchesOrientation(catOrientation)) {
                                 categories.push({ id: cat.id, name: cat.name });
                             }
                         }


### PR DESCRIPTION
## Summary
- update the straight-only category flattener to respect sub-category orientation even when the parent group lacks the flag
- ensure single categories without an explicit orientation are still included in performer searches

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9aad56bec8324b6934eebdf2eb5e4