### PR TITLE
Fix multi-category performer search iteration

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -519,14 +519,19 @@ function LVJM_pageImportVideos() {
 
                     if (this.selectedCat && this.selectedCat !== 'all_straight') {
                         var prioritizedCategory = null;
+                        var remainingCategories = [];
+
                         lodash.each(categories, function (category) {
                             if (!prioritizedCategory && category.id === self.selectedCat) {
                                 prioritizedCategory = category;
+                                return;
                             }
+
+                            remainingCategories.push(category);
                         });
 
                         if (prioritizedCategory) {
-                            categories = [prioritizedCategory];
+                            categories = [prioritizedCategory].concat(remainingCategories);
                         }
                     }
 


### PR DESCRIPTION
## Summary
- keep the selected category at the front of the performer search queue without discarding other categories
- allow the automated performer search to iterate over every partner category from the dropdown

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b6ae60288324a6394eacc2a206f8