### PR TITLE
Refactor LiveJasmin search workflow and UI

### DIFF
--- a/admin/actions/ajax-get-embed-and-actors.php
+++ b/admin/actions/ajax-get-embed-and-actors.php
@@ -49,7 +49,9 @@ function lvjm_get_embed_and_actors( $params = '' ) {
         $primary_color         = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'primary-color' ) );
         $label_color           = str_replace( '#', '', xbox_get_field_value( 'lvjm-options', 'label-color' ) );
         $client_ip             = lvjm_get_client_ip_address();
-        error_log( '[WPS-LiveJasmin] Using client IP for embed details request: ' . $client_ip );
+        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                error_log( '[WPS-LiveJasmin] Using client IP for embed details request: ' . $client_ip );
+        }
         $api_url               = 'https://pt.ptawe.com/api/video-promotion/v1/details/' . $params['video_id'] . '?clientIp=' . $client_ip . '&primaryColor=' . $primary_color . '&labelColor=' . $label_color . '&psid=' . $psid . '&accessKey=' . $access_key;
         $args                  = array(
                 'timeout'   => 300,

--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -8,656 +8,946 @@
 // Exit if accessed directly.
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
-require_once LVJM_DIR . 'admin/class/class-lvjm-placeholder-parser.php';
-
 /**
  * Search Videos Class.
  *
- * @since 1.0.0
+ * Queries the LiveJasmin/AW Empire video-promotion API and prepares
+ * results for the admin UI.
  */
 class LVJM_Search_Videos {
 
+        /**
+         * Raw search params from the request.
+         *
+         * @var array
+         */
+        private $params = array();
 
-	/**
-	 * The params.
-	 *
-	 * @var array $params
-	 * @access private
-	 */
-	private $params;
+        /**
+         * Collected errors during the search lifecycle.
+         *
+         * @var array
+         */
+        private $errors = array();
 
-	/**
-	 * The errors.
-	 *
-	 * @var array $errors
-	 * @access private
-	 */
-	private $errors;
+        /**
+         * Normalized videos ready for the UI.
+         *
+         * @var array
+         */
+        private $videos = array();
 
-	/**
-	 * The feed_url.
-	 *
-	 * @var string $feed_url
-	 * @access private
-	 */
-	private $feed_url;
+        /**
+         * Metadata about the executed search.
+         *
+         * @var array
+         */
+        private $searched_data = array();
 
-	/**
-	 * The feed_infos.
-	 *
-	 * @var object $feed_infos
-	 * @access private
-	 */
-	private $feed_infos;
+        /**
+         * Current WordPress version (used for HTTP User-Agent header).
+         *
+         * @var string
+         */
+        private $wp_version = '';
 
-	/**
-	 * The videos.
-	 *
-	 * @var array $videos
-	 * @access private
-	 */
-	private $videos;
+        /**
+         * Sexual orientation used for the API request.
+         *
+         * @var string
+         */
+        private $orientation = 'straight';
 
-	/**
-	 * The searched_data.
-	 *
-	 * @var array $searched_data
-	 * @access private
-	 */
-	private $searched_data;
+        /**
+         * Normalized partner category slug for the current search.
+         *
+         * @var string
+         */
+        private $category_slug = '';
 
-	/**
-	 * The wp_version.
-	 *
-	 * @var string $wp_version
-	 * @access private
-	 */
-	private $wp_version;
+        /**
+         * LiveJasmin credentials (psid & accessKey).
+         *
+         * @var array
+         */
+        private $credentials = array();
 
-	/**
-	 * The partner_existing_videos_ids.
-	 *
-	 * @var array $partner_existing_videos_ids
-	 * @access private
-	 */
-	private $partner_existing_videos_ids;
+        /**
+         * Maximum amount of videos returned per API call.
+         *
+         * @var int
+         */
+        private $max_results_per_request = 60;
 
-	/**
-	 * The partner_unwanted_videos_ids.
-	 *
-	 * @var array $partner_unwanted_videos_ids
-	 * @access private
-	 */
-	private $partner_unwanted_videos_ids;
+        /**
+         * API list endpoint base URL.
+         *
+         * @var string
+         */
+        private $list_endpoint = 'https://pt.ptawe.com/api/video-promotion/v1/list';
 
-	/**
-	 * Item constructor.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param array $params The params needed to make the search.
-	 * @return void
-	 */
+        /**
+         * Constructor.
+         *
+         * @param array $params Parameters for the search.
+         */
         public function __construct( $params ) {
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                error_log( '[WPS-LiveJasmin] class-lvjm-search-videos.php constructor called' );
-                error_log( '[WPS-LiveJasmin] Search Param cat_s: ' . ( isset( $params['cat_s'] ) ? print_r( $params['cat_s'], true ) : '' ) );
-        }
                 global $wp_version;
+
                 $this->wp_version = $wp_version;
-               $this->params     = $params;
-               $this->errors     = array();
+                $this->params     = is_array( $params ) ? $params : array();
 
-                // connecting to API.
-                $api_params = array(
-			'license_key'  => WPSCORE()->get_license_key(),
-			'signature'    => WPSCORE()->get_client_signature(),
-			'server_addr'  => WPSCORE()->get_server_addr(),
-			'server_name'  => WPSCORE()->get_server_name(),
-			'core_version' => WPSCORE_VERSION,
-			'time'         => ceil( time() / 1000 ),
-			'partner_id'   => $this->params['partner']['id'],
-		);
+                $this->initialize_defaults();
 
-                $args = array(
-                        'timeout'   => 50,
-                        'sslverify' => true,
-                );
-
-                $base64_params = base64_encode( wp_json_encode( $api_params ) );
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                error_log( '[WPS-LiveJasmin] API Params: ' . print_r( $api_params, true ) );
-                error_log( '[WPS-LiveJasmin] API URL: ' . WPSCORE()->get_api_url( 'lvjm/get_feed', $base64_params ) );
-        }
-
-                $response = wp_remote_get( WPSCORE()->get_api_url( 'lvjm/get_feed', $base64_params ), $args );
-        if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-                error_log( '[WPS-LiveJasmin] Raw API Response: ' . wp_remote_retrieve_body( $response ) );
-        }
-
-		if ( ! is_wp_error( $response ) && 'application/json; charset=UTF-8' === $response['headers']['content-type'] ) {
-
-			$response_body = json_decode( wp_remote_retrieve_body( $response ) );
-
-			if ( null === $response_body ) {
-				WPSCORE()->write_log( 'error', 'Connection to API (get_feed) failed (null)', __FILE__, __LINE__ );
-				return false;
-			} elseif ( 200 !== $response_body->data->status ) {
-				WPSCORE()->write_log( 'error', 'Connection to API (get_feed) failed (status: <code>' . $response_body->data->status . '</code> message: <code>' . $response_body->message . '</code>)', __FILE__, __LINE__ );
-				return false;
-			} else {
-				// success.
-				if ( isset( $response_body->data->feed_infos ) ) {
-					$this->feed_infos = $response_body->data->feed_infos;
-					$this->feed_url   = $this->get_partner_feed_infos( $this->feed_infos->feed_url->data );
-
-                                        $saved_partner_options = WPSCORE()->get_product_option( 'LVJM', $this->params['partner']['id'] . '_options' );
-                                        $psid                 = '';
-                                        $access_key           = '';
-
-                                        if ( is_array( $saved_partner_options ) ) {
-                                                $psid       = isset( $saved_partner_options['psid'] ) ? sanitize_text_field( (string) $saved_partner_options['psid'] ) : '';
-                                                $access_key = isset( $saved_partner_options['accesskey'] ) ? sanitize_text_field( (string) $saved_partner_options['accesskey'] ) : '';
-                                        }
-
-                                        if ( empty( $psid ) ) {
-                                                $psid = sanitize_text_field( (string) get_option( 'wps_lj_psid' ) );
-                                        }
-
-                                        if ( empty( $access_key ) ) {
-                                                $access_key = sanitize_text_field( (string) get_option( 'wps_lj_accesskey' ) );
-                                        }
-
-                                       if ( empty( $psid ) || empty( $access_key ) ) {
-                                               error_log( '[WPS-LiveJasmin ERROR] Missing PSID or AccessKey – cannot build feed URL.' );
-                                               $this->errors = array(
-                                                       'code'     => 'missing_credentials',
-                                                       'message'  => __( 'Your AWEmpire PSID or Access Key is missing.', 'wps-livejasmin' ),
-                                                       'solution' => __( 'Please add both credentials in the LiveJasmin settings.', 'wps-livejasmin' ),
-                                               );
-
-                                               return false;
-                                       }
-
-                                        $base_url  = 'https://pt.ptawe.com/api/video-promotion/v1/list';
-                                        $client_ip = lvjm_get_client_ip_address();
-                                        error_log( '[WPS-LiveJasmin] Using client IP for video search feed: ' . $client_ip );
-                                        $default_limit = 120;
-                                        $max_limit     = 200;
-
-                                        $limit = 0;
-                                        if ( isset( $this->params['limit'] ) ) {
-                                                $limit = absint( $this->params['limit'] );
-                                        }
-
-                                        if ( empty( $limit ) ) {
-                                                $limit = $default_limit;
-                                        } else {
-                                                $limit = min( $limit, $max_limit );
-                                        }
-
-                                        $params    = array(
-                                                'site'              => 'wl3',
-                                                'tags'              => isset( $this->params['cat_s'] ) ? $this->params['cat_s'] : '',
-                                                'sexualOrientation' => 'straight',
-                                                'language'          => 'en',
-                                                'clientIp'          => $client_ip,
-                                                'limit'             => $limit,
-                                                'psid'              => $psid,
-                                                'accessKey'         => $access_key,
-                                                'primaryColor'      => 'be0000',
-                                                'labelColor'        => 'FFFFFF',
-                                        );
-
-                                        // Append performer filter if provided.
-                                        if ( isset( $this->params['performer'] ) && ! empty( $this->params['performer'] ) ) {
-                                                $params['forcedPerformers'] = trim( $this->params['performer'] );
-                                        }
-
-                                        $this->feed_url = $base_url . '?' . http_build_query( $params );
-
-                                        error_log( '[WPS-LiveJasmin] Final hard-coded feed URL: ' . $this->feed_url );
-
-					if ( ! $this->feed_url ) {
-						WPSCORE()->write_log( 'error', 'Connection to Partner\'s API failed (feed url: <code>' . $this->feed_url . '</code> partner id: <code>:' . $this->params['partner']['id'] . '</code>)', __FILE__, __LINE__ );
-						return false;
-					}
-					switch ( $this->params['partner']['data_type'] ) {
-						case 'json':
-							return $this->retrieve_videos_from_json_feed();
-						default:
-							break;
-					}
-				} else {
-					WPSCORE()->write_log( 'error', 'Connection to API (get_feed) failed (message: <code>' . $response_body->message . '</code>)', __FILE__, __LINE__ );
-				}
-			}
-		} elseif ( isset( $response->errors['http_request_failed'] ) ) {
-				WPSCORE()->write_log( 'error', 'Connection to API (get_feed) failed (error: <code>' . wp_json_encode( $response->errors ) . '</code>)', __FILE__, __LINE__ );
-				return false;
-		}
-		return false;
-	}
-
-	/**
-	 * Get videos from the current object.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The videos.
-	 */
-	public function get_videos() {
-		return $this->videos;
-	}
-
-	/**
-	 * Get searched data.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The searched data.
-	 */
-	public function get_searched_data() {
-		return $this->searched_data;
-	}
-
-	/**
-	 * Get errors.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The errors caught.
-	 */
-	public function get_errors() {
-		return $this->errors;
-	}
-
-	/**
-	 * Get errors.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return bool true if there are some errors, false if not.
-	 */
-	public function has_errors() {
-		return ! empty( $this->errors );
-	}
-
-	/**
-	 * Gett feed url with orientation.
-	 *
-	 * @since 1.0.7
-	 *
-	 * @return string The feed url with orientation.
-	 */
-	private function get_feed_url_with_orientation() {
-		$parsed_url = wp_parse_url( $this->feed_url );
-		parse_str( $parsed_url['query'], $old_query );
-		$new_query = array();
-                foreach ( $old_query as $key => $value ) {
-                        if ( 'tags' !== $key ) {
-                                $new_query[ $key ] = $value;
-                                continue;
-                        }
-
-                        $decoded_tags = rawurldecode( $value );
-
-                        $orientation_terms = array(
-                                'gay'     => 'gay',
-                                'shemale' => 'shemale',
-                        );
-
-                        $orientation = 'straight';
-                        $pattern     = '/\s+(' . implode( '|', array_map( 'preg_quote', array_keys( $orientation_terms ) ) ) . ')$/i';
-
-                        if ( preg_match( $pattern, $decoded_tags, $matches ) ) {
-                                $matched_term = strtolower( $matches[1] );
-                                if ( isset( $orientation_terms[ $matched_term ] ) ) {
-                                        $orientation = $orientation_terms[ $matched_term ];
-                                }
-                                $decoded_tags = preg_replace( $pattern, '', $decoded_tags );
-                        } else {
-                                foreach ( $orientation_terms as $term => $orientation_value ) {
-                                        if ( false !== stripos( $decoded_tags, $term ) ) {
-                                                $orientation = $orientation_value;
-                                                break;
-                                        }
-                                }
-                        }
-
-                        $new_query['tags']              = trim( $decoded_tags );
-                        $new_query['sexualOrientation'] = $orientation;
+                if ( ! $this->validate_partner() ) {
+                        return;
                 }
-                $parsed_url['query'] = http_build_query( $new_query, '', '&', PHP_QUERY_RFC3986 );
-		$feed_url            = $this->unparse_url( $parsed_url );
-		return $feed_url;
-	}
 
-	/**
-	 * Unparse a parsed url.
-	 *
-	 * @param array $parsed_url The parsed url.
-	 *
-	 * @return string The unparsed url.
-	 */
-	private function unparse_url( $parsed_url ) {
-		$scheme   = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '';
-		$host     = isset( $parsed_url['host'] ) ? $parsed_url['host'] : '';
-		$port     = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
-		$user     = isset( $parsed_url['user'] ) ? $parsed_url['user'] : '';
-		$pass     = isset( $parsed_url['pass'] ) ? ':' . $parsed_url['pass'] : '';
-		$pass     = ( $user || $pass ) ? "$pass@" : '';
-		$path     = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
-		$query    = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
-		$fragment = isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '';
-		return "$scheme$user$pass$host$port$path$query$fragment";
-	}
+                $this->orientation   = $this->determine_orientation();
+                $this->category_slug = $this->determine_category_slug();
 
-	/**
-	 * Find videos from a json feed.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return bool true if there are no error, false if not.
-	 */
-	private function retrieve_videos_from_json_feed() {
-                $existing_ids           = $this->get_partner_existing_ids();
-                $existing_lookup        = array_flip( (array) $existing_ids['partner_existing_videos_ids'] );
-                $removed_lookup         = array_flip( (array) $existing_ids['partner_unwanted_videos_ids'] );
-                $array_valid_videos     = array();
-                $counters               = array(
-                        'valid_videos'    => 0,
-                        'invalid_videos'  => 0,
-                        'existing_videos' => 0,
-                        'removed_videos'  => 0,
-                );
-		$videos_details         = array();
-                $count_valid_feed_items = 0;
-                $end                    = false;
-                $total_pages            = null;
-                $max_pages_cutoff       = 50;
-
-		$root_feed_url = $this->get_feed_url_with_orientation();
-
-                $args = array(
-                        'timeout'   => 300,
-                        'sslverify' => true,
-                );
-
-		$args['user-agent'] = 'WordPress/' . $this->wp_version . '; ' . home_url();
-
-		if ( isset( $this->feed_infos->feed_auth ) ) {
-			$args['headers'] = array( 'Authorization' => $this->get_partner_feed_infos( $this->feed_infos->feed_auth->data ) );
-		}
-
-		$current_page = intval( $this->get_partner_feed_infos( $this->feed_infos->feed_first_page->data ) );
-
-		$paged = '';
-		if ( isset( $this->feed_infos->feed_paged ) ) {
-			$paged = $this->get_partner_feed_infos( $this->feed_infos->feed_paged->data );
-		}
-
-		$array_found_ids = array();
-
-                while ( false === $end ) {
-
-                        $log_performer = isset( $this->params['performer'] ) ? sanitize_text_field( (string) $this->params['performer'] ) : '';
-                        $log_category  = isset( $this->params['cat_s'] ) ? sanitize_text_field( (string) $this->params['cat_s'] ) : '';
-                        $category_for_log = $log_category;
-                        if ( '' === $category_for_log && isset( $this->params['category'] ) ) {
-                                $category_for_log = sanitize_text_field( (string) $this->params['category'] );
-                        }
-
-                        if ( null !== $total_pages && $current_page > $total_pages ) {
-                                error_log(
-                                        sprintf(
-                                                '[WPS-LiveJasmin] Reached total pages (%d). Performer: %s, Category: %s',
-                                                $total_pages,
-                                                '' === $log_performer ? 'n/a' : $log_performer,
-                                                '' === $category_for_log ? 'n/a' : $category_for_log
-                                        )
-                                );
-                                $end = true;
-                                break;
-                        }
-
-                        if ( $current_page > $max_pages_cutoff ) {
-                                error_log(
-                                        sprintf(
-                                                '[WPS-LiveJasmin] Safety cutoff triggered at page %d. Performer: %s, Category: %s',
-                                                $max_pages_cutoff,
-                                                '' === $log_performer ? 'n/a' : $log_performer,
-                                                '' === $category_for_log ? 'n/a' : $category_for_log
-                                        )
-                                );
-                                $end = true;
-                                break;
-                        }
-
-                        if ( '' !== $paged ) {
-                                        $this->feed_url = $root_feed_url . $paged . $current_page;
-                        }
-
-                        $log_feed_url  = $this->feed_url ? esc_url_raw( (string) $this->feed_url ) : '';
-
-                        error_log(
-                                sprintf(
-                                        '[WPS-LiveJasmin] Fetching page %d | Final feed URL: %s | performer: %s | category: %s',
-                                        $current_page,
-                                        '' === $log_feed_url ? 'n/a' : $log_feed_url,
-                                        '' === $log_performer ? 'n/a' : $log_performer,
-                                        '' === $log_category ? 'n/a' : $log_category
-                                )
+                $credentials = $this->resolve_credentials();
+                if ( is_wp_error( $credentials ) ) {
+                        $this->errors = array(
+                                'code'     => 'missing_credentials',
+                                'message'  => __( 'Your AWEmpire PSID or Access Key is missing.', 'wps-livejasmin' ),
+                                'solution' => __( 'Please add both credentials in the LiveJasmin settings.', 'wps-livejasmin' ),
                         );
-                        $response = wp_remote_get( $this->feed_url, $args );
+                        $this->log_debug( 'Missing LiveJasmin credentials. Aborting search.' );
+                        return;
+                }
+
+                $this->credentials = $credentials;
+
+                $this->retrieve_videos_from_api();
+        }
+
+        /**
+         * Prepare default structures for search data & counters.
+         */
+        private function initialize_defaults() {
+                $this->errors = array();
+                $this->videos = array();
+                $this->searched_data = array(
+                        'videos_details' => array(),
+                        'counters'       => array(
+                                'valid_videos'    => 0,
+                                'invalid_videos'  => 0,
+                                'existing_videos' => 0,
+                                'removed_videos'  => 0,
+                        ),
+                        'videos'     => array(),
+                        'pagination' => array(
+                                'pageIndex'  => 0,
+                                'pageSize'   => 0,
+                                'count'      => 0,
+                                'totalPages' => 0,
+                                'totalCount' => 0,
+                        ),
+                );
+        }
+
+        /**
+         * Ensure a partner is present in the params.
+         *
+         * @return bool
+         */
+        private function validate_partner() {
+                if ( empty( $this->params['partner'] ) || empty( $this->params['partner']['id'] ) ) {
+                        $this->errors = array(
+                                'code'     => 'missing_partner',
+                                'message'  => __( 'The partner configuration is missing.', 'wps-livejasmin' ),
+                                'solution' => __( 'Select a partner and try again.', 'wps-livejasmin' ),
+                        );
+                        return false;
+                }
+
+                return true;
+        }
+
+        /**
+         * Retrieve LiveJasmin credentials for the current partner.
+         *
+         * @return array|WP_Error
+         */
+        private function resolve_credentials() {
+                $partner_id = isset( $this->params['partner']['id'] ) ? sanitize_text_field( (string) $this->params['partner']['id'] ) : '';
+
+                $psid       = '';
+                $access_key = '';
+
+                if ( $partner_id ) {
+                        $saved_partner_options = WPSCORE()->get_product_option( 'LVJM', $partner_id . '_options' );
+                        if ( is_array( $saved_partner_options ) ) {
+                                if ( empty( $psid ) && ! empty( $saved_partner_options['psid'] ) ) {
+                                        $psid = sanitize_text_field( (string) $saved_partner_options['psid'] );
+                                }
+                                if ( empty( $access_key ) && ! empty( $saved_partner_options['accesskey'] ) ) {
+                                        $access_key = sanitize_text_field( (string) $saved_partner_options['accesskey'] );
+                                }
+                        }
+                }
+
+                $global_partner_options = WPSCORE()->get_product_option( 'LVJM', 'livejasmin_options' );
+                if ( is_array( $global_partner_options ) ) {
+                        if ( empty( $psid ) && ! empty( $global_partner_options['psid'] ) ) {
+                                $psid = sanitize_text_field( (string) $global_partner_options['psid'] );
+                        }
+                        if ( empty( $access_key ) && ! empty( $global_partner_options['accesskey'] ) ) {
+                                $access_key = sanitize_text_field( (string) $global_partner_options['accesskey'] );
+                        }
+                }
+
+                if ( empty( $psid ) ) {
+                        $psid = sanitize_text_field( (string) get_option( 'wps_lj_psid' ) );
+                }
+
+                if ( empty( $access_key ) ) {
+                        $access_key = sanitize_text_field( (string) get_option( 'wps_lj_accesskey' ) );
+                }
+
+                if ( '' === $psid || '' === $access_key ) {
+                        return new WP_Error( 'missing_credentials', 'Missing LiveJasmin credentials.' );
+                }
+
+                return array(
+                        'psid'       => $psid,
+                        'access_key' => $access_key,
+                );
+        }
+
+        /**
+         * Execute paginated requests against the LiveJasmin list endpoint.
+         */
+        private function retrieve_videos_from_api() {
+                $limit_total = $this->determine_limit();
+                $remaining   = $limit_total;
+                $page_index  = 0;
+                $max_pages   = 50;
+
+                $existing_ids = $this->get_partner_existing_ids();
+                $existing_lookup = array_flip( (array) $existing_ids['partner_existing_videos_ids'] );
+                $removed_lookup  = array_flip( (array) $existing_ids['partner_unwanted_videos_ids'] );
+
+                $videos_details      = array();
+                $valid_videos        = array();
+                $seen_ids            = array();
+                $total_pages_report  = null;
+                $total_count_report  = null;
+
+                while ( $remaining > 0 && $page_index < $max_pages ) {
+                        $per_page = min( $this->max_results_per_request, $remaining );
+                        $response = $this->request_page( $page_index, $per_page );
 
                         if ( is_wp_error( $response ) ) {
-                                WPSCORE()->write_log( 'error', 'Retrieving videos from JSON feed failed<code>ERROR: ' . wp_json_encode( $response->errors ) . '</code>', __FILE__, __LINE__ );
-                                return false;
+                                $this->handle_wp_error( $response );
+                                return;
                         }
 
-                        if ( 403 === wp_remote_retrieve_response_code( $response ) ) {
-                                WPSCORE()->write_log( 'error', 'Your AWEmpire PSID or Access Key is wrong. Please configure LiveJasmin.', __FILE__, __LINE__ );
+                        if ( isset( $response['status'] ) && 'ERROR' === strtoupper( (string) $response['status'] ) ) {
                                 $this->errors = array(
-                                        'code'     => 'AWEmpire credentials error',
-                                        'message'  => 'Your AWEmpire PSID or Access Key is wrong.',
-                                        'solution' => 'Please configure LiveJasmin.',
+                                        'code'     => 'api_error',
+                                        'message'  => __( 'LiveJasmin API returned an error.', 'wps-livejasmin' ),
+                                        'solution' => __( 'Please review your query and try again.', 'wps-livejasmin' ),
                                 );
-                                return false;
+                                $this->log_debug( 'LiveJasmin API returned an error payload.', array( 'payload' => $this->truncate_for_log( $response ) ) );
+                                return;
                         }
 
-                        $response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+                        $payload    = ( isset( $response['data'] ) && is_array( $response['data'] ) ) ? $response['data'] : $response;
+                        $videos     = isset( $payload['videos'] ) && is_array( $payload['videos'] ) ? $payload['videos'] : array();
+                        $pagination = isset( $payload['pagination'] ) && is_array( $payload['pagination'] ) ? $payload['pagination'] : array();
 
-                        if ( isset( $response_body['data']['pagination']['totalPages'] ) ) {
-                                $total_pages = (int) $response_body['data']['pagination']['totalPages'];
+                        if ( isset( $pagination['totalPages'] ) ) {
+                                $total_pages_report = (int) $pagination['totalPages'];
                         }
 
-                        if ( '' !== $log_performer ) {
-                                $results_count = 0;
-                                if ( isset( $response_body['data']['videos'] ) && is_array( $response_body['data']['videos'] ) ) {
-                                        $results_count = count( $response_body['data']['videos'] );
+                        if ( isset( $pagination['totalCount'] ) ) {
+                                $total_count_report = (int) $pagination['totalCount'];
+                        }
+
+                        $this->log_debug(
+                                'LiveJasmin page fetched.',
+                                array(
+                                        'pageIndex'  => $page_index,
+                                        'requested'  => $per_page,
+                                        'returned'   => count( $videos ),
+                                        'totalPages' => $total_pages_report,
+                                        'totalCount' => $total_count_report,
+                                )
+                        );
+
+                        if ( empty( $videos ) ) {
+                                break;
+                        }
+
+                        $stop_after_page = false;
+
+                        foreach ( (array) $videos as $raw_video ) {
+                                if ( $remaining <= 0 ) {
+                                        $stop_after_page = true;
+                                        break;
                                 }
 
-                                error_log(
-                                        sprintf(
-                                                '[WPS-LiveJasmin] Testing performer: %s | category: %s | results: %d',
-                                                $log_performer,
-                                                '' === $category_for_log ? 'n/a' : $category_for_log,
-                                                $results_count
-                                        )
-                                );
-                        }
-
-                        if ( $response_body['status'] && 'ERROR' === $response_body['status'] ) {
-                                $end              = true;
-                                $page_end         = true;
-                                $videos_details[] = array(
-                                        'id'       => 'end',
-                                        'response' => 'livejasmin API Error',
-                                );
-                        }
-
-                        // feed url last page reached.
-                        if ( 0 === count( (array) $response_body['data']['videos'] ) ) {
-                                error_log(
-                                        sprintf(
-                                                '[WPS-LiveJasmin] No videos found, ending loop. Performer: %s, Category: %s',
-                                                '' === $log_performer ? 'n/a' : $log_performer,
-                                                '' === $category_for_log ? 'n/a' : $category_for_log
-                                        )
-                                );
-                                $end              = true;
-                                $page_end         = true;
-                                $videos_details[] = array(
-                                        'id'       => 'end',
-                                        'response' => 'No more videos',
-                                );
-                        } else {
-                                // améliorer root selon paramètres / ou si null dans la config.
-                                if ( isset( $this->feed_infos->feed_item_path->node ) ) {
-                                        $root       = $this->feed_infos->feed_item_path->node;
-                                        $array_feed = $response_body['data'][ $root ];
-                                } else {
-                                        $root       = 0;
-                                        $array_feed = $response_body['data'];
-                                }
-                                $count_total_feed_items = count( $array_feed );
-                                $current_item           = 0;
-                                $page_end               = false;
-                        }
-                        while ( false === $page_end ) {
-                                $feed_item = new LVJM_Json_Item( $array_feed[ $current_item ] );
-                                $feed_item->init( $this->params, $this->feed_infos );
-                                if ( $feed_item->is_valid() ) {
-                                        $video_id   = $feed_item->get_id();
-                                        $video_data = (array) $feed_item->get_data_for_json( $count_valid_feed_items );
-                                        $status     = 'valid';
-
-                                        if ( isset( $existing_lookup[ $video_id ] ) ) {
-                                                $status                       = 'existing';
-                                                $video_data['already_imported'] = true;
-                                                $video_data['checked']          = false;
-                                        } elseif ( isset( $removed_lookup[ $video_id ] ) ) {
-                                                $status                       = 'removed';
-                                                $video_data['already_imported'] = false;
-                                                $video_data['checked']          = false;
-                                        } else {
-                                                $video_data['already_imported'] = false;
-                                        }
-
-                                        $video_data['import_status'] = $status;
-                                        $array_valid_videos[]        = $video_data;
-
-                                        switch ( $status ) {
-                                                case 'existing':
-                                                        $videos_details[] = array(
-                                                                'id'       => $video_id,
-                                                                'response' => 'Already imported',
-                                                        );
-                                                        ++$counters['existing_videos'];
-                                                        break;
-                                                case 'removed':
-                                                        $videos_details[] = array(
-                                                                'id'       => $video_id,
-                                                                'response' => 'You removed it from search results',
-                                                        );
-                                                        ++$counters['removed_videos'];
-                                                        break;
-                                                default:
-                                                        $videos_details[] = array(
-                                                                'id'       => $video_id,
-                                                                'response' => 'Success',
-                                                        );
-                                                        ++$counters['valid_videos'];
-                                                        break;
-                                        }
-
-                                        ++$count_valid_feed_items;
-                                } else {
+                                $normalized = $this->normalize_video_item( (array) $raw_video );
+                                if ( empty( $normalized ) ) {
                                         $videos_details[] = array(
-                                                'id'       => $feed_item->get_id(),
+                                                'id'       => isset( $raw_video['id'] ) ? (string) $raw_video['id'] : 'invalid',
                                                 'response' => 'Invalid',
                                         );
-                                        ++$counters['invalid_videos'];
+                                        ++$this->searched_data['counters']['invalid_videos'];
+                                        continue;
                                 }
-                                if ( $current_item >= ( $count_total_feed_items - 1 ) ) {
-                                        $page_end = true;
-                                        ++$current_page;
-                                        if ( '' === $paged ) {
-                                                $end = true;
-                                        }
+
+                                $video_id = (string) $normalized['id'];
+                                if ( isset( $seen_ids[ $video_id ] ) ) {
+                                        continue;
                                 }
-                                ++$current_item;
+
+                                $seen_ids[ $video_id ] = true;
+
+                                $status = 'valid';
+                                if ( isset( $existing_lookup[ $video_id ] ) ) {
+                                        $status                         = 'existing';
+                                        $normalized['already_imported'] = true;
+                                        $normalized['checked']          = false;
+                                } elseif ( isset( $removed_lookup[ $video_id ] ) ) {
+                                        $status                         = 'removed';
+                                        $normalized['already_imported'] = false;
+                                        $normalized['checked']          = false;
+                                } else {
+                                        $normalized['already_imported'] = false;
+                                }
+
+                                $normalized['import_status'] = $status;
+
+                                $valid_videos[] = $normalized;
+
+                                switch ( $status ) {
+                                        case 'existing':
+                                                $videos_details[] = array(
+                                                        'id'       => $video_id,
+                                                        'response' => 'Already imported',
+                                                );
+                                                ++$this->searched_data['counters']['existing_videos'];
+                                                break;
+                                        case 'removed':
+                                                $videos_details[] = array(
+                                                        'id'       => $video_id,
+                                                        'response' => 'You removed it from search results',
+                                                );
+                                                ++$this->searched_data['counters']['removed_videos'];
+                                                break;
+                                        default:
+                                                $videos_details[] = array(
+                                                        'id'       => $video_id,
+                                                        'response' => 'Success',
+                                                );
+                                                ++$this->searched_data['counters']['valid_videos'];
+                                                break;
+                                }
+
+                                --$remaining;
+                        }
+
+                        if ( $stop_after_page ) {
+                                break;
+                        }
+
+                        ++$page_index;
+
+                        if ( null !== $total_pages_report && $page_index >= $total_pages_report ) {
+                                break;
                         }
                 }
-                unset( $array_feed );
-		$this->searched_data = array(
-			'videos_details' => $videos_details,
-			'counters'       => $counters,
-			'videos'         => $array_valid_videos,
-		);
-		$this->videos        = $array_valid_videos;
-		return true;
-	}
 
-	/**
-	 * Get partner feed info from a feed item given.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @param string $partner_feed_item The partner item.
-	 * @return string The feede info.
-	 */
-        private function get_partner_feed_infos( $partner_feed_item ) {
-                $saved_partner_options = WPSCORE()->get_product_option( 'LVJM', $this->params['partner']['id'] . '_options' );
-                $context               = array(
-                        'partner_options' => is_array( $saved_partner_options ) ? $saved_partner_options : array(),
-                        'params'          => $this->params,
-                );
+                $fetched_pages = $page_index;
+                if ( ! empty( $valid_videos ) && $remaining <= 0 ) {
+                        $fetched_pages = $page_index + 1;
+                }
 
-                return LVJM_Placeholder_Parser::parse( $partner_feed_item, $context );
+                $this->searched_data['videos_details']            = $videos_details;
+                $this->searched_data['videos']                    = $valid_videos;
+                $this->searched_data['pagination']['pageIndex']   = max( 0, $fetched_pages - 1 );
+                $this->searched_data['pagination']['pageSize']    = min( $this->max_results_per_request, $limit_total );
+                $this->searched_data['pagination']['count']       = count( $valid_videos );
+                $this->searched_data['pagination']['totalPages']  = ( null !== $total_pages_report ) ? $total_pages_report : max( 1, $fetched_pages );
+                $this->searched_data['pagination']['totalCount']  = ( null !== $total_count_report ) ? $total_count_report : count( $valid_videos );
+
+                $this->videos = $valid_videos;
         }
 
-	/**
-	 * Get partner feed info from a feed item given.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The feede info.
-	 */
-	private function get_partner_existing_ids() {
-		// retrieve existing ids from imported videos.
-		global $wpdb;
+        /**
+         * Handle WP_Error responses from the API request.
+         *
+         * @param WP_Error $error Error instance.
+         */
+        private function handle_wp_error( WP_Error $error ) {
+                switch ( $error->get_error_code() ) {
+                        case 'livejasmin_credentials':
+                                $this->errors = array(
+                                        'code'     => 'AWEmpire credentials error',
+                                        'message'  => __( 'Your AWEmpire PSID or Access Key is wrong.', 'wps-livejasmin' ),
+                                        'solution' => __( 'Please configure LiveJasmin.', 'wps-livejasmin' ),
+                                );
+                                break;
+                        default:
+                                $this->errors = array(
+                                        'code'     => 'api_error',
+                                        'message'  => __( 'There was an error communicating with the LiveJasmin API.', 'wps-livejasmin' ),
+                                        'solution' => __( 'Please try again later.', 'wps-livejasmin' ),
+                                );
+                                break;
+                }
 
-		$custom_post_type = xbox_get_field_value( 'lvjm-options', 'custom-video-post-type' );
-		$custom_post_type = '' !== $custom_post_type ? $custom_post_type : 'post';
+                $this->log_debug( 'LiveJasmin API request failed.', array( 'error' => $error->get_error_message() ) );
+        }
 
-		$query_str = "
-			SELECT wposts.ID, wpostmetaVideoId.meta_value videoId
-			FROM $wpdb->posts wposts, $wpdb->postmeta wpostmetasponsor, $wpdb->postmeta wpostmetaVideoId
-			WHERE wposts.ID = wpostmetasponsor.post_id
-			AND ( wpostmetasponsor.meta_key = 'partner' AND wpostmetasponsor.meta_value = %s )
-			AND (wposts.ID =  wpostmetaVideoId.post_id AND wpostmetaVideoId.meta_key = 'video_id')
-			AND wposts.post_type = %s
-		";
+        /**
+         * Determine the amount of results requested for the search.
+         *
+         * @return int
+         */
+        private function determine_limit() {
+                $limit = isset( $this->params['limit'] ) ? absint( $this->params['limit'] ) : 0;
+                if ( $limit <= 0 ) {
+                        $limit = 30;
+                }
 
-		$bdd_videos                  = $wpdb->get_results( $wpdb->prepare( $query_str, $this->params['partner']['id'], $custom_post_type ), OBJECT );
-		$partner_existing_videos_ids = array();
-		foreach ( (array) $bdd_videos as $bdd_video ) {
-			$partner_existing_videos_ids[] = $bdd_video->videoId;
-		}
-		unset( $bdd_videos );
-		// retrieve existing ids from unwanted videos.
-		$partner_unwanted_videos_ids = array();
-		$unwanted_videos_ids         = WPSCORE()->get_product_option( 'LVJM', 'removed_videos_ids' );
-		if ( isset( $unwanted_videos_ids[ $this->params['partner']['id'] ] ) && is_array( $unwanted_videos_ids[ $this->params['partner']['id'] ] ) ) {
-			$partner_unwanted_videos_ids = $unwanted_videos_ids[ $this->params['partner']['id'] ];
-		}
-		unset( $unwanted_videos_ids );
-		return array(
-			'partner_existing_videos_ids' => $partner_existing_videos_ids,
-			'partner_unwanted_videos_ids' => $partner_unwanted_videos_ids,
-			'partner_all_videos_ids'      => array_merge( $partner_existing_videos_ids, $partner_unwanted_videos_ids ),
-		);
-	}
+                return max( 1, $limit );
+        }
+
+        /**
+         * Build the LiveJasmin API query parameters.
+         *
+         * @param int $page_index Zero based page index.
+         * @param int $limit      Number of videos requested for the page.
+         * @return array
+         */
+        private function build_request_args( $page_index, $limit ) {
+                $client_ip = function_exists( 'lvjm_get_client_ip_address' ) ? lvjm_get_client_ip_address() : '';
+
+                $args = array(
+                        'psid'              => $this->credentials['psid'],
+                        'accessKey'         => $this->credentials['access_key'],
+                        'limit'             => max( 1, min( $this->max_results_per_request, absint( $limit ) ) ),
+                        'pageIndex'         => max( 0, absint( $page_index ) ),
+                        'sexualOrientation' => $this->orientation,
+                        'site'              => 'wl3',
+                        'language'          => 'en',
+                );
+
+                if ( $client_ip ) {
+                        $args['clientIp'] = $client_ip;
+                }
+
+                $tags = $this->determine_tags();
+                if ( '' !== $tags ) {
+                        $args['tags'] = $tags;
+                }
+
+                $performer = isset( $this->params['performer'] ) ? sanitize_text_field( (string) $this->params['performer'] ) : '';
+                if ( '' !== $performer ) {
+                        $args['forcedPerformers'] = $performer;
+                }
+
+                if ( isset( $this->params['tags'] ) && '' === $tags && ! empty( $this->params['tags'] ) ) {
+                        $args['tags'] = sanitize_text_field( (string) $this->params['tags'] );
+                }
+
+                return $args;
+        }
+
+        /**
+         * Perform a single HTTP request to the list endpoint.
+         *
+         * @param int $page_index Page index.
+         * @param int $limit      Page size.
+         * @return array|WP_Error
+         */
+        private function request_page( $page_index, $limit ) {
+                $query_args    = $this->build_request_args( $page_index, $limit );
+                $query_string  = http_build_query( $query_args, '', '&', PHP_QUERY_RFC3986 );
+                $request_url   = $this->list_endpoint . '?' . $query_string;
+                $masked_params = $query_args;
+
+                if ( isset( $masked_params['psid'] ) ) {
+                        $masked_params['psid'] = $this->mask_value( $masked_params['psid'] );
+                }
+                if ( isset( $masked_params['accessKey'] ) ) {
+                        $masked_params['accessKey'] = $this->mask_value( $masked_params['accessKey'] );
+                }
+
+                $this->log_debug(
+                        'Requesting LiveJasmin list endpoint.',
+                        array(
+                                'url'    => $this->list_endpoint,
+                                'params' => $masked_params,
+                        )
+                );
+
+                $args = array(
+                        'timeout'   => 45,
+                        'sslverify' => true,
+                        'headers'   => array(
+                                'Accept' => 'application/json',
+                        ),
+                        'user-agent' => 'WordPress/' . $this->wp_version . '; ' . home_url(),
+                );
+
+                $response = wp_remote_get( $request_url, $args );
+                if ( is_wp_error( $response ) ) {
+                                return $response;
+                }
+
+                $status_code = wp_remote_retrieve_response_code( $response );
+                if ( 403 === $status_code ) {
+                        return new WP_Error( 'livejasmin_credentials', 'Unauthorized LiveJasmin credentials.' );
+                }
+
+                if ( $status_code < 200 || $status_code >= 300 ) {
+                        return new WP_Error( 'http_error', 'Unexpected HTTP status code: ' . $status_code );
+                }
+
+                $body = wp_remote_retrieve_body( $response );
+                $data = json_decode( $body, true );
+
+                if ( null === $data ) {
+                        return new WP_Error( 'invalid_json', 'Unable to decode LiveJasmin response.' );
+                }
+
+                return $data;
+        }
+
+        /**
+         * Normalize a single video item from the LiveJasmin API response.
+         *
+         * @param array $item Video item.
+         * @return array|null
+         */
+        private function normalize_video_item( array $item ) {
+                $video_id = $this->extract_first_non_empty( $item, array( 'id', 'videoId', 'video_id', 'code' ) );
+                if ( '' === $video_id ) {
+                        return null;
+                }
+
+                $title = $this->extract_first_non_empty( $item, array( 'title', 'name', 'headline' ) );
+                $desc  = $this->extract_first_non_empty( $item, array( 'description', 'desc', 'summary', 'shortDescription' ) );
+
+                $tags_value = $this->extract_first_non_empty( $item, array( 'tags', 'categories', 'keywords' ) );
+                $tags_list  = $this->sanitize_text_list( $tags_value );
+                $tags       = implode( ', ', $tags_list );
+
+                $duration_value = $this->extract_first_non_empty( $item, array( 'lengthSeconds', 'duration', 'length', 'durationSeconds' ) );
+                $duration       = $this->normalize_duration( $duration_value );
+
+                $thumb_url_value = $this->extract_first_non_empty( $item, array( 'mainThumbnailUrl', 'thumbUrl', 'thumbnailUrl', 'previewUrl', 'imageUrl', 'previewImage' ) );
+                $thumb_url       = esc_url_raw( (string) $thumb_url_value );
+
+                $thumbs_value = $this->extract_first_non_empty( $item, array( 'thumbnailSet', 'thumbs', 'thumbnails', 'images', 'snapshotUrls', 'previewImages' ) );
+                $thumbs_urls  = $this->sanitize_url_list( $thumbs_value );
+
+                if ( empty( $thumbs_urls ) && '' !== $thumb_url ) {
+                        $thumbs_urls = array( $thumb_url );
+                }
+
+                $trailer_value = $this->extract_first_non_empty( $item, array( 'trailerUrl', 'previewVideoUrl', 'teaserUrl', 'trailerVideoUrl' ) );
+                $video_url     = $this->extract_first_non_empty( $item, array( 'videoUrl', 'videoLink', 'videoDownloadUrl', 'streamUrl' ) );
+                $tracking_url  = $this->extract_first_non_empty( $item, array( 'trackingUrl', 'joinUrl', 'clickUrl', 'targetUrl' ) );
+
+                $quality = $this->extract_first_non_empty( $item, array( 'quality', 'videoQuality' ) );
+                $is_hd   = $this->extract_first_non_empty( $item, array( 'isHd', 'hd', 'hdVideo' ) );
+                if ( is_bool( $is_hd ) ) {
+                        $is_hd = $is_hd ? '1' : '0';
+                } elseif ( is_numeric( $is_hd ) ) {
+                        $is_hd = ( (int) $is_hd ) ? '1' : '0';
+                } else {
+                        $is_hd = '' !== $is_hd ? (string) $is_hd : '';
+                }
+
+                $uploader_value = $this->extract_first_non_empty( $item, array( 'uploader', 'channel', 'studio', 'siteName' ) );
+
+                $actors_value = $this->extract_first_non_empty( $item, array( 'performers', 'models', 'actors' ) );
+                $actors_list  = $this->sanitize_text_list( $actors_value );
+                $actors       = implode( ', ', $actors_list );
+
+                return array(
+                        'id'           => (string) $video_id,
+                        'title'        => LVJM_Item::clean_string( (string) $title ),
+                        'desc'         => is_string( $desc ) ? wp_kses_post( $desc ) : '',
+                        'tags'         => LVJM_Item::clean_string( $tags ),
+                        'duration'     => (string) $duration,
+                        'thumb_url'    => $thumb_url,
+                        'thumbs_urls'  => $thumbs_urls,
+                        'trailer_url'  => esc_url_raw( (string) $trailer_value ),
+                        'video_url'    => esc_url_raw( (string) $video_url ),
+                        'tracking_url' => esc_url_raw( (string) $tracking_url ),
+                        'quality'      => is_string( $quality ) ? $quality : '',
+                        'isHd'         => $is_hd,
+                        'uploader'     => LVJM_Item::clean_string( (string) $uploader_value ),
+                        'embed'        => '',
+                        'actors'       => LVJM_Item::clean_string( $actors ),
+                        'partner_cat'  => $this->category_slug,
+                        'checked'      => true,
+                        'grabbed'      => false,
+                );
+        }
+
+        /**
+         * Extract the first non-empty value from an array by trying multiple keys.
+         * Supports dot notation for nested arrays/objects.
+         *
+         * @param array        $source Array to inspect.
+         * @param array|string $keys   Keys to inspect.
+         * @return mixed
+         */
+        private function extract_first_non_empty( array $source, $keys ) {
+                $keys = (array) $keys;
+                foreach ( $keys as $key ) {
+                        $value = $this->get_value_from_path( $source, $key );
+                        if ( is_array( $value ) ) {
+                                if ( ! empty( $value ) ) {
+                                        return $value;
+                                }
+                        } elseif ( null !== $value && '' !== trim( (string) $value ) ) {
+                                return $value;
+                        }
+                }
+
+                return '';
+        }
+
+        /**
+         * Retrieve a value from an array using a dot-notated path.
+         *
+         * @param array  $source Array to inspect.
+         * @param string $path   Path (supports dot notation).
+         * @return mixed
+         */
+        private function get_value_from_path( array $source, $path ) {
+                if ( '' === $path ) {
+                        return '';
+                }
+
+                $segments = explode( '.', $path );
+                $value    = $source;
+
+                foreach ( $segments as $segment ) {
+                        if ( is_array( $value ) && array_key_exists( $segment, $value ) ) {
+                                $value = $value[ $segment ];
+                        } elseif ( is_object( $value ) && isset( $value->$segment ) ) {
+                                $value = $value->$segment;
+                        } else {
+                                return '';
+                        }
+                }
+
+                return $value;
+        }
+
+        /**
+         * Convert a raw duration value into seconds.
+         *
+         * @param mixed $value Raw duration value.
+         * @return int
+         */
+        private function normalize_duration( $value ) {
+                if ( is_numeric( $value ) ) {
+                        return absint( $value );
+                }
+
+                if ( ! is_string( $value ) ) {
+                        return 0;
+                }
+
+                $value = trim( $value );
+                if ( '' === $value ) {
+                        return 0;
+                }
+
+                if ( preg_match( '/^(\d+):(\d+):(\d+)$/', $value, $matches ) ) {
+                        return ( (int) $matches[1] * 3600 ) + ( (int) $matches[2] * 60 ) + (int) $matches[3];
+                }
+
+                if ( preg_match( '/^(\d+):(\d+)$/', $value, $matches ) ) {
+                        return ( (int) $matches[1] * 60 ) + (int) $matches[2];
+                }
+
+                if ( preg_match( '/^(\d+)$/', $value ) ) {
+                        return absint( $value );
+                }
+
+                return 0;
+        }
+
+        /**
+         * Sanitize a list of text values into a flat array of unique strings.
+         *
+         * @param mixed $value Raw value.
+         * @return array
+         */
+        private function sanitize_text_list( $value ) {
+                $values = array();
+
+                if ( is_array( $value ) ) {
+                        $values = $value;
+                } elseif ( is_string( $value ) ) {
+                        if ( false !== strpos( $value, ';' ) ) {
+                                $values = explode( ';', $value );
+                        } elseif ( false !== strpos( $value, ',' ) ) {
+                                $values = explode( ',', $value );
+                        } elseif ( false !== strpos( $value, '|' ) ) {
+                                $values = explode( '|', $value );
+                        } elseif ( '' !== $value ) {
+                                $values = array( $value );
+                        }
+                }
+
+                $sanitized = array();
+                foreach ( (array) $values as $single ) {
+                        if ( is_array( $single ) ) {
+                                $single = implode( ' ', $single );
+                        }
+                        $single = trim( wp_strip_all_tags( (string) $single ) );
+                        if ( '' !== $single ) {
+                                $sanitized[] = $single;
+                        }
+                }
+
+                return array_values( array_unique( $sanitized ) );
+        }
+
+        /**
+         * Sanitize a list of URLs into an array.
+         *
+         * @param mixed $value Raw value.
+         * @return array
+         */
+        private function sanitize_url_list( $value ) {
+                $values = array();
+
+                if ( is_array( $value ) ) {
+                        $values = $value;
+                } elseif ( is_string( $value ) ) {
+                        if ( false !== strpos( $value, ';' ) || false !== strpos( $value, ',' ) ) {
+                                $values = preg_split( '/[;,]/', $value );
+                        } elseif ( '' !== $value ) {
+                                $values = array( $value );
+                        }
+                }
+
+                $urls = array();
+                foreach ( (array) $values as $single ) {
+                        if ( is_array( $single ) ) {
+                                if ( isset( $single['url'] ) ) {
+                                        $single = $single['url'];
+                                } elseif ( isset( $single['src'] ) ) {
+                                        $single = $single['src'];
+                                } else {
+                                        $single = reset( $single );
+                                }
+                        }
+                        $single = esc_url_raw( trim( (string) $single ) );
+                        if ( '' !== $single ) {
+                                $urls[] = $single;
+                        }
+                }
+
+                return array_values( array_unique( $urls ) );
+        }
+
+        /**
+         * Determine the appropriate orientation for the request.
+         *
+         * @return string
+         */
+        private function determine_orientation() {
+                if ( isset( $this->params['sexualOrientation'] ) && '' !== $this->params['sexualOrientation'] ) {
+                        return sanitize_text_field( (string) $this->params['sexualOrientation'] );
+                }
+
+                $category = '';
+                if ( isset( $this->params['cat_s'] ) && '' !== $this->params['cat_s'] ) {
+                        $category = (string) $this->params['cat_s'];
+                } elseif ( isset( $this->params['category'] ) && '' !== $this->params['category'] ) {
+                        $category = (string) $this->params['category'];
+                }
+
+                $category = strtolower( $category );
+                if ( false !== strpos( $category, 'shemale' ) || false !== strpos( $category, 'trans' ) ) {
+                        return 'shemale';
+                }
+
+                if ( false !== strpos( $category, 'gay' ) ) {
+                        return 'gay';
+                }
+
+                return 'straight';
+        }
+
+        /**
+         * Determine the normalized partner category slug for metadata.
+         *
+         * @return string
+         */
+        private function determine_category_slug() {
+                $category = '';
+                if ( isset( $this->params['cat_s'] ) && '' !== $this->params['cat_s'] ) {
+                        $category = (string) $this->params['cat_s'];
+                } elseif ( isset( $this->params['category'] ) && '' !== $this->params['category'] ) {
+                        $category = (string) $this->params['category'];
+                }
+
+                if ( '' === $category ) {
+                        return '';
+                }
+
+                if ( function_exists( 'lvjm_normalize_category_slug' ) ) {
+                        return lvjm_normalize_category_slug( $category );
+                }
+
+                return sanitize_title( $category );
+        }
+
+        /**
+         * Determine tags value passed to the API.
+         *
+         * @return string
+         */
+        private function determine_tags() {
+                if ( isset( $this->params['tags'] ) && '' !== $this->params['tags'] ) {
+                        return sanitize_text_field( (string) $this->params['tags'] );
+                }
+
+                if ( isset( $this->params['cat_s'] ) && '' !== $this->params['cat_s'] ) {
+                        return (string) $this->params['cat_s'];
+                }
+
+                return '';
+        }
+
+        /**
+         * Log debug messages when WP_DEBUG is enabled.
+         *
+         * @param string $message Message to log.
+         * @param array  $context Contextual data.
+         */
+        private function log_debug( $message, array $context = array() ) {
+                if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                        if ( ! empty( $context ) ) {
+                                $message .= ' ' . wp_json_encode( $context );
+                        }
+                        error_log( '[WPS-LiveJasmin] ' . $message );
+                }
+        }
+
+        /**
+         * Mask sensitive values before logging.
+         *
+         * @param string $value Value to mask.
+         * @return string
+         */
+        private function mask_value( $value ) {
+                $value   = (string) $value;
+                $length  = strlen( $value );
+                $visible = min( 3, $length );
+                $prefix  = substr( $value, 0, $visible );
+                return $prefix . str_repeat( '*', max( 0, $length - $visible ) );
+        }
+
+        /**
+         * Shorten large payloads before logging them.
+         *
+         * @param mixed $value Value to truncate.
+         * @return string
+         */
+        private function truncate_for_log( $value ) {
+                $encoded = wp_json_encode( $value );
+                if ( ! is_string( $encoded ) ) {
+                        return '';
+                }
+
+                if ( strlen( $encoded ) > 2000 ) {
+                        return substr( $encoded, 0, 2000 ) . '…';
+                }
+
+                return $encoded;
+        }
+
+        /**
+         * Get videos collected during the search.
+         *
+         * @return array
+         */
+        public function get_videos() {
+                return $this->videos;
+        }
+
+        /**
+         * Get metadata about the executed search.
+         *
+         * @return array
+         */
+        public function get_searched_data() {
+                return $this->searched_data;
+        }
+
+        /**
+         * Get errors collected during the search.
+         *
+         * @return array
+         */
+        public function get_errors() {
+                return $this->errors;
+        }
+
+        /**
+         * Determine whether the search finished with errors.
+         *
+         * @return bool
+         */
+        public function has_errors() {
+                return ! empty( $this->errors );
+        }
+
+        /**
+         * Retrieve already imported and removed video identifiers.
+         *
+         * @return array
+         */
+        private function get_partner_existing_ids() {
+                global $wpdb;
+
+                $custom_post_type = xbox_get_field_value( 'lvjm-options', 'custom-video-post-type' );
+                $custom_post_type = '' !== $custom_post_type ? $custom_post_type : 'post';
+
+                $query_str = "
+                        SELECT wposts.ID, wpostmetaVideoId.meta_value videoId
+                        FROM $wpdb->posts wposts, $wpdb->postmeta wpostmetasponsor, $wpdb->postmeta wpostmetaVideoId
+                        WHERE wposts.ID = wpostmetasponsor.post_id
+                        AND ( wpostmetasponsor.meta_key = 'partner' AND wpostmetasponsor.meta_value = %s )
+                        AND (wposts.ID =  wpostmetaVideoId.post_id AND wpostmetaVideoId.meta_key = 'video_id')
+                        AND wposts.post_type = %s
+                ";
+
+                $bdd_videos                  = $wpdb->get_results( $wpdb->prepare( $query_str, $this->params['partner']['id'], $custom_post_type ), OBJECT );
+                $partner_existing_videos_ids = array();
+                foreach ( (array) $bdd_videos as $bdd_video ) {
+                        $partner_existing_videos_ids[] = $bdd_video->videoId;
+                }
+                unset( $bdd_videos );
+
+                $partner_unwanted_videos_ids = array();
+                $unwanted_videos_ids         = WPSCORE()->get_product_option( 'LVJM', 'removed_videos_ids' );
+                if ( isset( $unwanted_videos_ids[ $this->params['partner']['id'] ] ) && is_array( $unwanted_videos_ids[ $this->params['partner']['id'] ] ) ) {
+                        $partner_unwanted_videos_ids = $unwanted_videos_ids[ $this->params['partner']['id'] ];
+                }
+                unset( $unwanted_videos_ids );
+
+                return array(
+                        'partner_existing_videos_ids' => $partner_existing_videos_ids,
+                        'partner_unwanted_videos_ids' => $partner_unwanted_videos_ids,
+                        'partner_all_videos_ids'      => array_merge( $partner_existing_videos_ids, $partner_unwanted_videos_ids ),
+                );
+        }
 }

--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -712,7 +712,15 @@ function LVJM_pageImportVideos() {
                                 trackSeen: true
                             });
                             var resultsCount = 0;
-                            if (response.body && lodash.isArray(response.body.videos)) {
+                            if (response.body && response.body.searched_data && response.body.searched_data.pagination) {
+                                var paginationInfo = response.body.searched_data.pagination;
+                                if (lodash.isNumber(paginationInfo.totalCount) && paginationInfo.totalCount > 0) {
+                                    resultsCount = paginationInfo.totalCount;
+                                } else if (lodash.isNumber(paginationInfo.count)) {
+                                    resultsCount = paginationInfo.count;
+                                }
+                            }
+                            if (!resultsCount && response.body && lodash.isArray(response.body.videos)) {
                                 resultsCount = response.body.videos.length;
                             }
                             self.recordPerformerCategoryResult({ id: category.id, name: category.name }, resultsCount, added);
@@ -810,7 +818,15 @@ function LVJM_pageImportVideos() {
                                 onlyNew: true
                             });
                             var resultsCount = 0;
-                            if (response.body && lodash.isArray(response.body.videos)) {
+                            if (response.body && response.body.searched_data && response.body.searched_data.pagination) {
+                                var fallbackPagination = response.body.searched_data.pagination;
+                                if (lodash.isNumber(fallbackPagination.totalCount) && fallbackPagination.totalCount > 0) {
+                                    resultsCount = fallbackPagination.totalCount;
+                                } else if (lodash.isNumber(fallbackPagination.count)) {
+                                    resultsCount = fallbackPagination.count;
+                                }
+                            }
+                            if (!resultsCount && response.body && lodash.isArray(response.body.videos)) {
                                 resultsCount = response.body.videos.length;
                             }
                             self.recordPerformerCategoryResult({ id: '', name: 'All Categories' }, resultsCount, added);

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -154,7 +154,7 @@ function lvjm_import_videos_page() {
                                                                                                 <input type="text" v-model="selectedPerformer" placeholder="<?php esc_attr_e( 'Performer (e.g., First Last)', 'lvjm_lang' ); ?>" id="performer_s" name="performer_s" class="form-control" style="width:220px;">
                                                                                                 <label class="checkbox-inline" style="margin-left:10px;">
                                                                                                         <input type="checkbox" v-model="performerAutoRunAll" v-bind:disabled="performerSearchActive">
-                                                                                                        <?php esc_html_e( 'Auto-run all categories', 'lvjm_lang' ); ?>
+                                                                                                        <?php esc_html_e( 'Full Auto Mode (run all categories)', 'lvjm_lang' ); ?>
                                                                                                 </label>
                                                                                         </span>
 
@@ -168,7 +168,7 @@ function lvjm_import_videos_page() {
 													</span>
 													<button v-show="!searchingVideos && !videosHasBeenSearched" v-on:click.prevent="searchVideos('create')" class="btn btn-info" v-bind:class="searchBtnClass" rel="tooltip" data-placement="top" v-bind:data-original-title="searchButtonTooltip"><i class="fa fa-search" aria-hidden="true"></i> <?php esc_html_e( 'Search videos', 'lvjm_lang' ); ?></button>
                                                                                                         <button v-show="searchingVideos" disabled="disabled" class="btn btn-info"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> <?php esc_html_e( 'Searching videos...', 'lvjm_lang' ); ?></button>
-                                                                                                       <button v-show="performerSearchActive && !performerAwaitingUserContinue" v-on:click.prevent="cancelPerformerSearch" class="btn btn-warning" style="margin-left:5px;"><i class="fa fa-stop-circle" aria-hidden="true"></i> <?php esc_html_e( 'Stop category search', 'lvjm_lang' ); ?></button>
+                                                                                                       <button v-show="performerSearchActive && !performerAwaitingUserContinue" v-on:click.prevent="cancelPerformerSearch" class="button button-secondary btn btn-warning" style="margin-left:5px;"><i class="fa fa-stop-circle" aria-hidden="true"></i> <?php esc_html_e( 'Stop category search', 'lvjm_lang' ); ?></button>
                                                                                                         <p class="text-info" v-if="performerSearchActive && currentSearchCategoryLabel">
                                                                                                                 <strong><?php esc_html_e( 'Currently searching category', 'lvjm_lang' ); ?></strong>:
                                                                                                                 {{ currentSearchCategoryLabel }}
@@ -192,28 +192,31 @@ function lvjm_import_videos_page() {
                                                                                                         <div v-if="performerCategorySummaries.length" class="margin-top-10">
                                                                                                                 <ul class="list-unstyled performer-category-log">
                                                                                                                         <li v-for="summary in performerCategorySummaries" v-bind:key="summary.id ? summary.id : summary.name">
-                                                                                                                                <strong><?php esc_html_e( 'Category', 'lvjm_lang' ); ?></strong> {{ summary.name }} &rarr; {{ summary.results }} <?php esc_html_e( 'results', 'lvjm_lang' ); ?>
+     <strong><?php esc_html_e( 'Category', 'lvjm_lang' ); ?></strong> {{ summary.name }} &rarr; {{ summary.results }} <?php esc_html_e( 'results', 'lvjm_lang' ); ?>
+             <span v-if="summary.displayed && summary.displayed > 0 && summary.displayed !== summary.results">(<?php esc_html_e( 'new', 'lvjm_lang' ); ?> {{ summary.displayed }})</span>
                                                                                                                         </li>
                                                                                                                 </ul>
                                                                                                         </div>
                                                                                                         <div v-if="performerSearchActive && performerAwaitingUserContinue" class="margin-top-10">
-                                                                                                                <button class="btn btn-success" v-on:click.prevent="continuePerformerCategorySearch"><span aria-hidden="true">✅</span> <?php esc_html_e( 'Continue Search in Next Category', 'lvjm_lang' ); ?></button>
-                                                                                                                <button class="btn btn-danger" style="margin-left:5px;" v-on:click.prevent="stopPerformerCategorySearch"><span aria-hidden="true">🛑</span> <?php esc_html_e( 'Stop Here', 'lvjm_lang' ); ?></button>
+                                                                                                                <button class="button button-primary btn btn-success" v-on:click.prevent="continuePerformerCategorySearch"><span aria-hidden="true">✅</span> <?php esc_html_e( 'Continue Search in Next Category', 'lvjm_lang' ); ?></button>
+                                                                                                                <button class="button button-secondary btn btn-danger" style="margin-left:5px;" v-on:click.prevent="stopPerformerCategorySearch"><span aria-hidden="true">🛑</span> <?php esc_html_e( 'Stop Here', 'lvjm_lang' ); ?></button>
                                                                                                         </div>
                                                                                                         <div v-if="performerSummaryComplete && performerCategorySummaries.length" class="margin-top-20">
                                                                                                                 <h4><?php esc_html_e( 'Performer Search Summary', 'lvjm_lang' ); ?></h4>
                                                                                                                 <div class="table-responsive">
-                                                                                                                        <table class="table table-bordered table-striped table-condensed">
+                                                                                                                        <table class="table table-bordered table-striped table-condensed widefat fixed striped">
                                                                                                                                 <thead>
                                                                                                                                         <tr>
                                                                                                                                                 <th><?php esc_html_e( 'Category', 'lvjm_lang' ); ?></th>
                                                                                                                                                 <th><?php esc_html_e( 'Results Found', 'lvjm_lang' ); ?></th>
+                <th><?php esc_html_e( 'New Videos Added', 'lvjm_lang' ); ?></th>
                                                                                                                                         </tr>
                                                                                                                                 </thead>
                                                                                                                                 <tbody>
                                                                                                                                         <tr v-for="summary in performerCategorySummaries" v-bind:key="'summary-' + (summary.id ? summary.id : summary.name)">
                                                                                                                                                 <td>{{ summary.name }}</td>
                                                                                                                                                 <td>{{ summary.results }}</td>
+                <td>{{ summary.displayed }}</td>
                                                                                                                                         </tr>
                                                                                                                                 </tbody>
                                                                                                                         </table>


### PR DESCRIPTION
## Summary
- refactor the server-side LiveJasmin search to use the official list API with credential handling, pagination safeguards, and sanitized debug logging
- update performer searches to track per-category results, reuse cached metadata, and present WordPress-styled controls plus a final summary table of totals and new videos
- ensure auxiliary embed requests only log client IP information when WP_DEBUG is enabled

## Testing
- php -l admin/class/class-lvjm-search-videos.php
- php -l admin/actions/ajax-search-videos.php
- php -l admin/pages/page-import-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68d9bdcae8f88324adf5917c71c4e41c