### PR TITLE
Improve multi-category reporting

### DIFF
--- a/admin/actions/ajax-load-partner-cats.php
+++ b/admin/actions/ajax-load-partner-cats.php
@@ -52,13 +52,16 @@ function lvjm_load_partner_cats() {
 		}
 		++$i;
 	}
-	// Inject custom category
-if (is_array($output) && isset($output[0]['id'])) {
-    array_unshift($output, array(
-        'id' => 'all_straight',
-        'name' => 'All Straight Categories'
-    ));
-}
+        // Inject custom category
+        if ( is_array( $output ) && isset( $output[0]['id'] ) ) {
+                array_unshift(
+                        $output,
+                        array(
+                                'id'   => 'all_categories',
+                                'name' => esc_html__( 'All Categories', 'lvjm_lang' ),
+                        )
+                );
+        }
 wp_send_json( $output );
 	wp_die();
 }

--- a/admin/actions/ajax-search-videos.php
+++ b/admin/actions/ajax-search-videos.php
@@ -1,104 +1,425 @@
 <?php
 defined( 'ABSPATH' ) || die( 'Cheatin&#8217; uh?' );
 
-/**
- * Search for videos in Ajax or PHP call, now supporting multi-category straight searches.
- */
-function lvjm_search_videos( $params = '' ) {
-    $ajax_call = '' === $params;
+if ( ! function_exists( 'lvjm_parse_performer_input' ) ) {
+    /**
+     * Parse a raw performer input string into sanitized performer names.
+     *
+     * @param string $raw_input Raw performer input from the UI.
+     * @return array List of sanitized performer names.
+     */
+    function lvjm_parse_performer_input( $raw_input ) {
+        $raw_input = (string) $raw_input;
 
-    if ( $ajax_call ) {
-        check_ajax_referer( 'ajax-nonce', 'nonce' );
-        $params = $_POST;
+        if ( '' === $raw_input ) {
+            return array();
+        }
+
+        $raw_input  = str_replace( array( "\r\n", "\r" ), "\n", $raw_input );
+        $chunks     = preg_split( '/[\n,;]+/', $raw_input );
+        $performers = array();
+
+        foreach ( (array) $chunks as $chunk ) {
+            $chunk = trim( $chunk );
+            if ( '' === $chunk ) {
+                continue;
+            }
+            $performers[] = sanitize_text_field( $chunk );
+        }
+
+        return array_values( array_unique( $performers ) );
     }
+}
 
-    $errors = array();
-    // Force brutal loop if All Straight Categories is chosen
-    if ( isset($params['cat_s']) && $params['cat_s'] === 'all_straight' ) {
-        $params['multi_category_search'] = '1';
-    }
+if ( ! function_exists( 'lvjm_get_mainstream_categories_for_search' ) ) {
+    /**
+     * Retrieve all mainstream (straight) categories in alphabetical order.
+     *
+     * @return array
+     */
+    function lvjm_get_mainstream_categories_for_search() {
+        $ordered_categories = LVJM()->get_ordered_categories();
+        $mainstream         = array();
 
-    $videos = array();
+        foreach ( (array) $ordered_categories as $category ) {
+            if ( ! isset( $category['id'] ) ) {
+                continue;
+            }
 
-    $is_multi_straight = isset($params['multi_category_search']) && $params['multi_category_search'] === '1';
-    $performer = isset($params['performer']) ? sanitize_text_field((string)$params['performer']) : '';
-
-    if ( $is_multi_straight ) {
-        $straight_categories = ['69', 'Above Average', 'Amateur', 'Anal', 'Angry', 'Asian', 'Ass', 'Ass To mouth', 'Athletic', 'Auburn Hair', 'Babe', 'Bald', 'Ball Sucking', 'Bathroom', 'Bbc', 'BBW', 'Bdsm', 'Bed', 'Big Ass', 'Big Boobs', 'Big Booty', 'Big Breasts', 'Big Cock', 'Big Tists', 'Bizarre', 'Black Eyes', 'Black Girl', 'Black Hair', 'Blonde', 'Blond Hair', 'Blowjob', 'Blue Eyes', 'Blue Hair', 'Bondage', 'Boots', 'Booty', 'Bossy', 'Brown Eyes', 'Brown Hair', 'Brunette', 'Butt Plug', 'Cam Girl', 'Cam Porn', 'Cameltoe', 'Celebrity', 'Cfnm', 'Cheerleader', 'Clown Hair', 'Cock', 'College Girl', 'Cop', 'Cosplay', 'Cougar', 'Couple', 'Cowgirl', 'Creampie', 'Crew Cut', 'Cum', 'Cum On Tits', 'Cumshot', 'Curious', 'Cut', 'Cute', 'Dance', 'Deepthroat', 'Dilde', 'Dirty', 'Doctor', 'Doggy', 'Domination', 'Double Penetration', 'Ebony', 'Erotic', 'Eye Contact', 'Facesitting', 'Facial', 'Fake Tits', 'Fat Ass', 'Fetish', 'Fingering', 'Fire Red Hair', 'Fishnet', 'Fisting', 'Flirting', 'Foot Sex', 'Footjob', 'Fuck', 'Gag', 'Gaping', 'Gilf', 'Girl', 'Glamour', 'Glasses', 'Green Eyes', 'Grey Eyes', 'Group', 'Gym', 'Hairy', 'Handjob', 'Hard Cock', 'Hd', 'High Heels', 'Homemade', 'Homy', 'Hot', 'Hot Flirt', 'Housewife', 'Huge Cock', 'Huge Tits', 'Innocent', 'Interracial', 'Intim Piercing', 'Jeans', 'Kitchen', 'Ladyboy', 'Large Build', 'Latex', 'Latin', 'Latina', 'Leather', 'Lesbian', 'Lick', 'Lingerie', 'Live Sex', 'Long Hair', 'Long Nails', 'Machine', 'Maid', 'Massage', 'Masturbation', 'Mature', 'Milf', 'Missionary', 'Misstress', 'Moaning', 'Muscular', 'Muslim', 'Naked', 'Nasty', 'Natural Tits', 'Normal Cock', 'Normal Tits', 'Nurse', 'Nylon', 'Office', 'Oiled', 'Orange Hair', 'Orgasm', 'Orgy', 'Outdoor', 'Party', 'Pawg', 'Petite', 'Piercing', 'Pink Hair', 'Pissing', 'Pool', 'Pov', 'Pregnant', 'Princess', 'Public', 'punish', 'Pussy', 'Pvc', 'Quicky', 'Redhead', 'Remote Toy', 'Reverse Cowgirl', 'Riding', 'Rimjob', 'Roleplay', 'Romantic', 'Room', 'Rough', 'Schoolgirl', 'Scissoring', 'Scream', 'Secretary', 'Sensual', 'Sextoy', 'Sexy', 'Shaved', 'Short Girl', 'Short Hair', 'Shoulder Lenght Hair', 'Shy', 'Skinny', 'Slave', 'Sloppy', 'Slutty', 'Small Ass', 'Small Cock', 'Smoking', 'Solo', 'Sologirl', 'squirt', 'Stockings', 'Strap On', 'Stretching', 'Striptease', 'Stroking', 'Suck', 'Swallow', 'Tall', 'Tattoo', 'Teacher', 'Teasing', 'Teen', 'Treesome', 'Tight', 'Tiny Tits', 'Titjob', 'Toy', 'Trimmed', 'Uniform', 'Virgin', 'Watching', 'Wet', 'White', 'Lesbian'];
-
-        $seen_ids = array();
-        foreach ( $straight_categories as $cat ) {
-            $params['category'] = $cat;
-            $params['cat_s'] = $cat;
-            $search_videos = new LVJM_Search_Videos( $params );
-
-            if ( ! $search_videos->has_errors() ) {
-                $new_videos = $search_videos->get_videos();
-                foreach ($new_videos as $v) {
-                    $vid = null;
-                    if (is_array($v)) {
-                        $vid = isset($v['id']) ? $v['id'] : null;
-                    } elseif (is_object($v)) {
-                        $vid = isset($v->id) ? $v->id : null;
-                    }
-                    if ($vid && !isset($seen_ids[$vid])) {
-                        $videos[] = $v;
-                        $seen_ids[$vid] = true;
+            if ( 'optgroup' === $category['id'] ) {
+                if ( isset( $category['name'] ) && 0 === strcasecmp( $category['name'], 'Straight' ) && ! empty( $category['sub_cats'] ) ) {
+                    foreach ( (array) $category['sub_cats'] as $sub_category ) {
+                        if ( empty( $sub_category['id'] ) ) {
+                            continue;
+                        }
+                        $key                 = strtolower( $sub_category['id'] );
+                        $mainstream[ $key ] = array(
+                            'id'   => $sub_category['id'],
+                            'name' => $sub_category['name'],
+                        );
                     }
                 }
-
-                $msg = '→ ' . $cat . ' (' . count($new_videos) . ' videos)';
-                error_log('[WPS-LiveJasmin] Brutal search ' . $msg);
-                if (!isset($GLOBALS['lvjm_debug'])) { $GLOBALS['lvjm_debug'] = array(); }
-                $GLOBALS['lvjm_debug'][] = $msg;
-
+                continue;
             }
-        }
-    } else {
-        $search_videos = new LVJM_Search_Videos( $params );
-        if ( ! $search_videos->has_errors() ) {
-            $videos = $search_videos->get_videos();
-        }
-    }
 
-    // Performer filtering
-    if ( '' !== $performer ) {
-        $filtered = array();
+            $candidate_id = strtolower( (string) $category['id'] );
+            if ( false !== strpos( $candidate_id, 'gay' ) || false !== strpos( $candidate_id, 'shemale' ) || false !== strpos( $candidate_id, 'trans' ) ) {
+                continue;
+            }
+
+            $mainstream[ $candidate_id ] = array(
+                'id'   => $category['id'],
+                'name' => isset( $category['name'] ) ? $category['name'] : $category['id'],
+            );
+        }
+
+        uasort(
+            $mainstream,
+            function ( $a, $b ) {
+                return strcasecmp( $a['name'], $b['name'] );
+            }
+        );
+
+        return array_values( $mainstream );
+    }
+}
+
+if ( ! function_exists( 'lvjm_extract_video_id' ) ) {
+    /**
+     * Extract a video ID from either an array or an object representation.
+     *
+     * @param array|object $video The video payload.
+     * @return string|null The video ID if available.
+     */
+    function lvjm_extract_video_id( $video ) {
+        if ( is_array( $video ) && isset( $video['id'] ) ) {
+            return $video['id'];
+        }
+
+        if ( is_object( $video ) && isset( $video->id ) ) {
+            return $video->id;
+        }
+
+        return null;
+    }
+}
+
+if ( ! function_exists( 'lvjm_filter_videos_by_performers' ) ) {
+    /**
+     * Filter a set of videos by a list of performer names.
+     *
+     * @param array $videos     Videos to filter.
+     * @param array $performers Performer names to match.
+     * @return array{videos: array, matches: array}
+     */
+    function lvjm_filter_videos_by_performers( $videos, $performers ) {
+        $results = array(
+            'videos'  => array(),
+            'matches' => array(),
+        );
+
+        $performers = array_values(
+            array_filter(
+                (array) $performers,
+                function ( $performer ) {
+                    return '' !== $performer;
+                }
+            )
+        );
+
+        if ( empty( $performers ) ) {
+            $results['videos'] = array_values( (array) $videos );
+            return $results;
+        }
+
         if ( ! function_exists( 'lvjm_get_embed_and_actors' ) ) {
             $actions_file = dirname( __FILE__ ) . '/ajax-get-embed-and-actors.php';
             if ( file_exists( $actions_file ) ) {
                 require_once $actions_file;
             }
         }
-        foreach ( (array) $videos as $v ) {
-            $match = false;
-            $actors = isset($v['actors']) ? (string)$v['actors'] : '';
-            if ( '' !== $actors && false !== stripos( $actors, $performer ) ) {
-                $match = true;
-            } elseif ( function_exists( 'lvjm_get_embed_and_actors' ) && isset( $v['id'] ) ) {
-                try {
-                    $more = lvjm_get_embed_and_actors( array( 'video_id' => $v['id'] ) );
-                    if ( ! empty( $more['performer_name'] ) && false !== stripos( $more['performer_name'], $performer ) ) {
-                        $match = true;
-                        $v['actors'] = $more['performer_name'];
-                    }
-                } catch ( \Throwable $e ) {}
+
+        foreach ( $performers as $performer ) {
+            $results['matches'][ $performer ] = array(
+                'count'     => 0,
+                'video_ids' => array(),
+            );
+        }
+
+        foreach ( (array) $videos as $video ) {
+            $video_id = lvjm_extract_video_id( $video );
+            $actors   = '';
+
+            if ( is_array( $video ) && isset( $video['actors'] ) ) {
+                $actors = (string) $video['actors'];
+            } elseif ( is_object( $video ) && isset( $video->actors ) ) {
+                $actors = (string) $video->actors;
             }
-            if ( $match ) {
-                $filtered[] = $v;
+
+            $matched_performers = array();
+
+            foreach ( $performers as $performer ) {
+                if ( '' !== $actors && false !== stripos( $actors, $performer ) ) {
+                    $matched_performers[] = $performer;
+                }
+            }
+
+            if ( empty( $matched_performers ) && function_exists( 'lvjm_get_embed_and_actors' ) && $video_id ) {
+                try {
+                    $more = lvjm_get_embed_and_actors( array( 'video_id' => $video_id ) );
+                    if ( ! empty( $more['performer_name'] ) ) {
+                        foreach ( $performers as $performer ) {
+                            if ( false !== stripos( $more['performer_name'], $performer ) ) {
+                                $matched_performers[] = $performer;
+                                if ( is_array( $video ) ) {
+                                    $video['actors'] = $more['performer_name'];
+                                } elseif ( is_object( $video ) ) {
+                                    $video->actors = $more['performer_name'];
+                                }
+                            }
+                        }
+                    }
+                } catch ( \Throwable $e ) {
+                    // Keep fallback silent if the API call fails.
+                }
+            }
+
+            if ( empty( $matched_performers ) ) {
+                continue;
+            }
+
+            $results['videos'][] = $video;
+
+            foreach ( $matched_performers as $performer ) {
+                ++$results['matches'][ $performer ]['count'];
+                if ( $video_id ) {
+                    $results['matches'][ $performer ]['video_ids'][ $video_id ] = true;
+                }
             }
         }
-        $videos = $filtered;
+
+        $results['videos'] = array_values( $results['videos'] );
+
+        return $results;
+    }
+}
+
+/**
+ * Search for videos (Ajax or PHP call).
+ *
+ * The search can iterate through all mainstream categories when requested,
+ * ensuring performer filters are applied in every query.
+ *
+ * @param array $params Optional search parameters when called directly.
+ */
+function lvjm_search_videos( $params = '' ) {
+    $ajax_call = '' === $params;
+
+    if ( $ajax_call ) {
+        check_ajax_referer( 'ajax-nonce', 'nonce' );
+        $params = wp_unslash( $_POST );
+    } else {
+        $params = (array) $params;
+    }
+
+    $errors        = array();
+    $videos        = array();
+    $searched_data = array();
+
+    $cat_s_value = isset( $params['cat_s'] ) ? sanitize_text_field( (string) $params['cat_s'] ) : '';
+
+    if ( in_array( $cat_s_value, array( 'all_categories', 'all_straight' ), true ) ) {
+        $params['multi_category_search'] = '1';
+        $cat_s_value                     = 'all_categories';
+    }
+
+    $is_multi_category = isset( $params['multi_category_search'] ) && '1' === (string) $params['multi_category_search'];
+
+    $performer_raw  = isset( $params['performer'] ) ? $params['performer'] : '';
+    $performer_list = lvjm_parse_performer_input( $performer_raw );
+
+    $primary_performer = '';
+    if ( ! empty( $performer_list ) ) {
+        $primary_performer = $performer_list[0];
+    } elseif ( '' !== $performer_raw ) {
+        $primary_performer = sanitize_text_field( (string) $performer_raw );
+        $performer_list[]  = $primary_performer;
+    }
+
+    $params['performer'] = $primary_performer;
+
+    if ( $is_multi_category ) {
+        if ( empty( $performer_list ) ) {
+            $performer_list = array( '' );
+        }
+
+        $categories = lvjm_get_mainstream_categories_for_search();
+
+        if ( empty( $categories ) ) {
+            $errors[] = array(
+                'code'     => 'no_categories',
+                'message'  => esc_html__( 'No mainstream categories were found for the search.', 'lvjm_lang' ),
+                'solution' => esc_html__( 'Refresh the partner categories and try again.', 'lvjm_lang' ),
+            );
+        } else {
+            $performer_reports = array();
+            $unique_videos     = array();
+            $unique_ids        = array();
+
+            foreach ( $performer_list as $performer_name ) {
+                $category_reports     = array();
+                $performer_videos     = array();
+                $performer_unique_ids = array();
+
+                foreach ( $categories as $category ) {
+                    $category_params = $params;
+                    $category_params['cat_s']                 = $category['id'];
+                    $category_params['category']              = $category['id'];
+                    $category_params['multi_category_search'] = '1';
+                    $category_params['performer']             = $performer_name;
+
+                    $search_videos   = new LVJM_Search_Videos( $category_params );
+                    $category_videos = array();
+                    $category_count  = 0;
+
+                    if ( $search_videos->has_errors() ) {
+                        $errors = array_merge( $errors, (array) $search_videos->get_errors() );
+                    } else {
+                        $category_videos = (array) $search_videos->get_videos();
+                        $category_count  = count( $category_videos );
+
+                        foreach ( $category_videos as $video ) {
+                            $video_id = lvjm_extract_video_id( $video );
+
+                            if ( $video_id && isset( $performer_unique_ids[ $video_id ] ) ) {
+                                continue;
+                            }
+
+                            if ( $video_id ) {
+                                $performer_unique_ids[ $video_id ] = true;
+                            }
+
+                            $performer_videos[] = $video;
+
+                            if ( $video_id && isset( $unique_ids[ $video_id ] ) ) {
+                                continue;
+                            }
+
+                            if ( $video_id ) {
+                                $unique_ids[ $video_id ] = true;
+                            }
+
+                            $unique_videos[] = $video;
+                        }
+                    }
+
+                    $feed_url = method_exists( $search_videos, 'get_last_root_feed_url' ) ? $search_videos->get_last_root_feed_url() : '';
+                    $log_name = '' !== $performer_name ? $performer_name : '(no performer)';
+
+                    if ( $feed_url ) {
+                        error_log( sprintf( '[WPS-LiveJasmin] Category "%s" performer "%s" feed URL: %s', $category['name'], $log_name, $feed_url ) );
+                    }
+
+                    error_log( sprintf( '[WPS-LiveJasmin] Category "%s" performer "%s" results: %d', $category['name'], $log_name, $category_count ) );
+
+                    $category_reports[] = array(
+                        'id'           => $category['id'],
+                        'name'         => $category['name'],
+                        'videos_found' => $category_count,
+                    );
+                }
+
+                $performer_reports[] = array(
+                    'name'             => $performer_name,
+                    'display_name'     => '' !== $performer_name ? $performer_name : esc_html__( 'No performer filter', 'lvjm_lang' ),
+                    'video_count'      => count( $performer_videos ),
+                    'status'           => count( $performer_videos ) > 0,
+                    'category_reports' => $category_reports,
+                );
+            }
+
+            $videos = $unique_videos;
+
+            $filter_results = lvjm_filter_videos_by_performers( $videos, $performer_list );
+
+            if ( ! empty( $filter_results['videos'] ) || ! empty( $performer_list ) ) {
+                $videos = $filter_results['videos'];
+
+                if ( ! empty( $filter_results['matches'] ) ) {
+                    foreach ( $performer_reports as &$report ) {
+                        $name = $report['name'];
+                        if ( '' === $name ) {
+                            continue;
+                        }
+
+                        if ( isset( $filter_results['matches'][ $name ] ) ) {
+                            $report['video_count'] = $filter_results['matches'][ $name ]['count'];
+                            $report['status']      = $filter_results['matches'][ $name ]['count'] > 0;
+                        } else {
+                            $report['video_count'] = 0;
+                            $report['status']      = false;
+                        }
+                    }
+                    unset( $report );
+                }
+            }
+
+            $searched_data = array(
+                'videos_details' => array(),
+                'counters'       => array(
+                    'valid_videos' => count( $videos ),
+                ),
+                'videos'         => $videos,
+                'multi_category' => array(
+                    'performer_reports' => $performer_reports,
+                ),
+            );
+        }
+    } else {
+        $search_videos = new LVJM_Search_Videos( $params );
+
+        if ( $search_videos->has_errors() ) {
+            $errors = array_merge( $errors, (array) $search_videos->get_errors() );
+        } else {
+            $videos        = $search_videos->get_videos();
+            $searched_data = $search_videos->get_searched_data();
+
+            if ( ! empty( $performer_list ) ) {
+                $filter_results = lvjm_filter_videos_by_performers( $videos, $performer_list );
+                $videos         = $filter_results['videos'];
+
+                if ( ! isset( $searched_data['multi_category'] ) || ! is_array( $searched_data['multi_category'] ) ) {
+                    $searched_data['multi_category'] = array();
+                }
+
+                $reports = array();
+                foreach ( $performer_list as $performer_name ) {
+                    $count = isset( $filter_results['matches'][ $performer_name ] ) ? $filter_results['matches'][ $performer_name ]['count'] : 0;
+                    $reports[] = array(
+                        'name'             => $performer_name,
+                        'display_name'     => '' !== $performer_name ? $performer_name : esc_html__( 'No performer filter', 'lvjm_lang' ),
+                        'video_count'      => $count,
+                        'status'           => $count > 0,
+                        'category_reports' => array(),
+                    );
+                }
+
+                $searched_data['multi_category']['performer_reports'] = $reports;
+            }
+        }
     }
 
     if ( ! $ajax_call ) {
         return $videos;
     }
 
-    wp_send_json(array(
-        'videos'        => $videos,
-        'errors'        => $errors,
-    ));
+    wp_send_json(
+        array(
+            'videos'        => array_values( (array) $videos ),
+            'errors'        => $errors,
+            'searched_data' => $searched_data,
+        )
+    );
 
     wp_die();
 }

--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -32,13 +32,21 @@ class LVJM_Search_Videos {
 	 */
 	private $errors;
 
-	/**
-	 * The feed_url.
-	 *
-	 * @var string $feed_url
-	 * @access private
-	 */
-	private $feed_url;
+        /**
+         * The feed_url.
+         *
+         * @var string $feed_url
+         * @access private
+         */
+        private $feed_url;
+
+        /**
+         * The last root feed URL used for a search.
+         *
+         * @var string $last_root_feed_url
+         * @access private
+         */
+        private $last_root_feed_url = '';
 
 	/**
 	 * The feed_infos.
@@ -97,12 +105,12 @@ class LVJM_Search_Videos {
 	 * @return void
 	 */
 	public function __construct( $params ) {
-        error_log('[WPS-LiveJasmin] class-lvjm-search-videos.php constructor called');
-        error_log('[WPS-LiveJasmin] class-lvjm-search-videos.php constructor called');
-		global $wp_version;
-		$this->wp_version = $wp_version;
-		$this->params     = $params;
-        error_log('[WPS-LiveJasmin] Search Param cat_s: ' . print_r($this->params['cat_s'], true));
+                global $wp_version;
+                $this->wp_version = $wp_version;
+                $this->params     = $params;
+                error_log( '[WPS-LiveJasmin] class-lvjm-search-videos.php constructor called' );
+                $cat_s_log = isset( $this->params['cat_s'] ) ? print_r( $this->params['cat_s'], true ) : '(unset)';
+                error_log( '[WPS-LiveJasmin] Search Param cat_s: ' . $cat_s_log );
 
 		// connecting to API.
 		$api_params = array(
@@ -121,12 +129,11 @@ class LVJM_Search_Videos {
 		);
 
 		$base64_params = base64_encode( wp_json_encode( $api_params ) );
-        error_log('[WPS-LiveJasmin] API Params: ' . print_r($api_params, true));
-        error_log('[WPS-LiveJasmin] API URL: ' . WPSCORE()->get_api_url('lvjm/get_feed', $base64_params));
+                error_log( '[WPS-LiveJasmin] API Params: ' . print_r( $api_params, true ) );
+                error_log( '[WPS-LiveJasmin] API URL: ' . WPSCORE()->get_api_url( 'lvjm/get_feed', $base64_params ) );
 
-		$response = wp_remote_get( WPSCORE()->get_api_url( 'lvjm/get_feed', $base64_params ), $args );
-		$response = wp_remote_get( WPSCORE()->get_api_url( 'lvjm/get_feed', $base64_params ), $args );
-        error_log('[WPS-LiveJasmin] Raw API Response: ' . wp_remote_retrieve_body($response));
+                $response = wp_remote_get( WPSCORE()->get_api_url( 'lvjm/get_feed', $base64_params ), $args );
+                error_log( '[WPS-LiveJasmin] Raw API Response: ' . wp_remote_retrieve_body( $response ) );
 
 		if ( ! is_wp_error( $response ) && 'application/json; charset=UTF-8' === $response['headers']['content-type'] ) {
 
@@ -186,22 +193,33 @@ class LVJM_Search_Videos {
 		return false;
 	}
 
-	/**
-	 * Get videos from the current object.
-	 *
-	 * @since 1.0.0
-	 *
-	 * @return array The videos.
-	 */
-	public function get_videos() {
-		return $this->videos;
-	}
+        /**
+         * Get videos from the current object.
+         *
+         * @since 1.0.0
+         *
+         * @return array The videos.
+         */
+        public function get_videos() {
+                return $this->videos;
+        }
 
-	/**
-	 * Get searched data.
-	 *
-	 * @since 1.0.0
-	 *
+        /**
+         * Get the last root feed URL that was generated for this search.
+         *
+         * @since 1.0.8
+         *
+         * @return string The last root feed URL.
+         */
+        public function get_last_root_feed_url() {
+                return $this->last_root_feed_url;
+        }
+
+        /**
+         * Get searched data.
+         *
+         * @since 1.0.0
+         *
 	 * @return array The searched data.
 	 */
 	public function get_searched_data() {
@@ -302,7 +320,8 @@ class LVJM_Search_Videos {
 		$count_valid_feed_items = 0;
 		$end                    = false;
 
-		$root_feed_url = $this->get_feed_url_with_orientation();
+                $root_feed_url           = $this->get_feed_url_with_orientation();
+                $this->last_root_feed_url = $root_feed_url;
 
 		$args = array(
 			'timeout'   => 300,

--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -90,7 +90,6 @@ function LVJM_pageImportVideos() {
 
                 partnerCatsLoading: false,
                 partnerCats: [],
-                selectedPartnerCats: '',
 
                 // allPartnersCounter: 0,
                 filteredPartnersCounter: 0,
@@ -207,6 +206,13 @@ function LVJM_pageImportVideos() {
                     }).length;
                 },
                 selectedPartnerCatName: function () {
+                    if (this.selectedCat === 'all_categories') {
+                        if (this.data.objectL10n && this.data.objectL10n.all_categories) {
+                            return this.data.objectL10n.all_categories;
+                        }
+                        return 'All Categories';
+                    }
+
                     var self = this;
                     if (this.selectedPartnerObject != '') {
                         var name;
@@ -252,6 +258,13 @@ function LVJM_pageImportVideos() {
                 },
                 videosCounter: function () {
                     return this.videos.length;
+                },
+                performerReports: function () {
+                    if (!this.searchedData || !this.searchedData.multi_category) {
+                        return [];
+                    }
+                    var reports = this.searchedData.multi_category.performer_reports;
+                    return Array.isArray(reports) ? reports : [];
                 },
                 searchBtnClass: function () {
                     if (this.selectedCat == '' && this.selectedKW == '') {
@@ -329,11 +342,6 @@ function LVJM_pageImportVideos() {
                 loadPartnerCats: function () {
                     this.partnerCatsLoading = true;
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                             LVJM_import_videos.ajax.url, {
@@ -402,11 +410,14 @@ function LVJM_pageImportVideos() {
                     var cat_s = '';
                     var kw = '';
                     var partnerId = '';
+                    var partner = null;
 
                     //reset searching states
                     this.videos = [];
                     this.searchingVideos = true;
                     this.videosHasBeenSearched = false;
+                    this.videosSearchedErrors = {};
+                    this.searchedData = {};
 
                     if (feedId === undefined) {
 
@@ -452,13 +463,8 @@ function LVJM_pageImportVideos() {
                     //jQuery('[rel=tooltip]').tooltip('hide');
 
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
-    
+
                             LVJM_import_videos.ajax.url, {
                                 action: 'lvjm_search_videos',
                                 cat_s: cat_s,
@@ -468,6 +474,7 @@ function LVJM_pageImportVideos() {
                                 limit: this.data.videosLimit,
                                 method: method,
                                 nonce: LVJM_import_videos.ajax.nonce,
+                                multi_category_search: this.selectedCat === 'all_categories' ? 1 : 0,
                                 original_cat_s: cat_s.replace('&', '%%'),
                                 partner: partner,
                                 performer: this.selectedPerformer
@@ -477,7 +484,7 @@ function LVJM_pageImportVideos() {
                         .then(function (response) {
                             var videos = this.videos;
                             if (lodash.isEmpty(response.body.errors)) {
-                                this.searchedData = response.body.searched_data;
+                                this.searchedData = response.body.searched_data || {};
                                 lodash.each(response.body.videos, function (video) {
                                     videos.push({
                                         id: video.id,
@@ -593,11 +600,6 @@ function LVJM_pageImportVideos() {
                     video.loading.removing = true;
                     this.loading.removingVideo = true;
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                             LVJM_import_videos.ajax.url, {
@@ -813,11 +815,6 @@ function LVJM_pageImportVideos() {
                 deleteFeed: function () {
                     this.loading.deleteFeed = true;
                     
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                             LVJM_import_videos.ajax.url, {
@@ -847,11 +844,6 @@ function LVJM_pageImportVideos() {
                 this.loading.loadingData = true;
                 var self = this;
                 
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                         LVJM_import_videos.ajax.url, {
@@ -1089,11 +1081,6 @@ function LVJM_pageImportVideos() {
                         saveOptions: function () {
                             this.loading.savingOptions = true;
                             
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                                     LVJM_import_videos.ajax.url, {
@@ -1267,11 +1254,6 @@ function LVJM_pageImportVideos() {
                         changeStatus: function (newValue) {
                             this.loading.savingOptions = this.loading.savingStatus = true;
                             
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                                     LVJM_import_videos.ajax.url, {
@@ -1295,11 +1277,6 @@ function LVJM_pageImportVideos() {
                         toggleAutoImport: function (newValue) {
                             this.loading.savingOptions = this.loading.savingAutoImport = true;
                             
-                    // Injected: support for All Straight Categories
-                    if (this.selectedPartnerCats === 'all_straight') {
-                        postData.multi_category_search = 1;
-                    }
-
                     this.$http.post(
     
                                     LVJM_import_videos.ajax.url, {

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -147,10 +147,11 @@ function lvjm_import_videos_page() {
 															<span id="kw-search" v-show="selectedPartnerObject.filters.search_by == 'keyword'">
 															<strong>- <?php esc_html_e( 'OR', 'lvjm_lang' ); ?> -</strong> <?php esc_html_e( 'Enter some keywords', 'lvjm_lang' ); ?> <input v-model="selectedKW" v-bind:disabled="searchingVideos" v-on:keyup.enter.prevent="searchVideos('create')" id="kw_s" type="text" placeholder="<?php esc_html_e( 'eg. ebony lesbian', 'lvjm_lang' ); ?>" name="kw_s" class="form-control" style="width:250px;">
 															</span>
-											<span id="performer-search" style="margin-left:8px;">
-												<label for="performer_s" class="sr-only"><?php esc_html_e( 'Performer', 'lvjm_lang' ); ?></label>
-												<input type="text" v-model="selectedPerformer" placeholder="<?php esc_attr_e( 'Performer (optional)', 'lvjm_lang' ); ?>" id="performer_s" name="performer_s" class="form-control" style="width:220px;">
-											</span>
+                                                                                        <span id="performer-search" style="margin-left:8px;">
+                                                                                                <label for="performer_s" class="sr-only"><?php esc_html_e( 'Performer', 'lvjm_lang' ); ?></label>
+                                                                                                <textarea v-model="selectedPerformer" placeholder="<?php esc_attr_e( 'Performer (optional)', 'lvjm_lang' ); ?>" id="performer_s" name="performer_s" class="form-control" style="width:220px;height:70px;resize:vertical;" rows="3"></textarea>
+                                                                                                <small class="help-block" style="margin-bottom:0;"><?php esc_html_e( 'Separate multiple performers with commas or new lines.', 'lvjm_lang' ); ?></small>
+                                                                                        </span>
 
 														</div>
 													</div>
@@ -170,8 +171,37 @@ function lvjm_import_videos_page() {
 									</div>
 									<!-- / search videos block -->
 									<!-- results success block -->
-									<div class="row">
-										<div class="col-xs-12" v-show="videosCounter <= 0 && videosHasBeenSearched">                                        
+                                                                        <div class="row">
+                                                                                                                                                                                                                                                <div v-if="performerReports.length" class="col-xs-12 margin-top-10">
+                                                                                        <h4 class="margin-top-0"><?php esc_html_e( 'All Categories search summary', 'lvjm_lang' ); ?></h4>
+                                                                                        <div class="panel panel-default" v-for="(report, index) in performerReports" v-bind:key="index" style="margin-bottom:15px;">
+                                                                                                <div class="panel-heading clearfix">
+                                                                                                        <strong>{{ report.display_name || report.name }}</strong>
+                                                                                                        <span class="pull-right" v-bind:class="[report.status ? 'text-success' : 'text-danger']">{{ report.status ? '✅' : '❌' }}</span>
+                                                                                                </div>
+                                                                                                <div class="panel-body">
+                                                                                                        <p class="margin-bottom-10"><strong>{{ report.video_count }}</strong> <?php esc_html_e( 'videos found across all categories.', 'lvjm_lang' ); ?></p>
+                                                                                                        <div v-if="report.category_reports && report.category_reports.length">
+                                                                                                                <table class="table table-condensed table-striped margin-bottom-0">
+                                                                                                                        <thead>
+                                                                                                                                <tr>
+                                                                                                                                        <th><?php esc_html_e( 'Category', 'lvjm_lang' ); ?></th>
+                                                                                                                                        <th class="text-right"><?php esc_html_e( 'Videos', 'lvjm_lang' ); ?></th>
+                                                                                                                                </tr>
+                                                                                                                        </thead>
+                                                                                                                        <tbody>
+                                                                                                                                <tr v-for="category in report.category_reports" v-bind:key="category.id" v-bind:class="{'success': parseInt(category.videos_found, 10) > 0}">
+                                                                                                                                        <td>{{ category.name }}</td>
+                                                                                                                                        <td class="text-right">{{ category.videos_found }}</td>
+                                                                                                                                </tr>
+                                                                                                                        </tbody>
+                                                                                                                </table>
+                                                                                                        </div>
+                                                                                                        <p v-else class="text-muted margin-bottom-0"><?php esc_html_e( 'No categories were returned for this performer.', 'lvjm_lang' ); ?></p>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </div>
+                                                                                <div class="col-xs-12" v-show="videosCounter <= 0 && videosHasBeenSearched">
 											<div v-if="videosSearchedErrors.code" class="alert alert-danger margin-top-10 text-center alert-dismissible" role="alert">
 												<button type="button" class="close" v-on:click.prevent="resetSearch" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 												<p><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> <strong>{{videosSearchedErrors.code}}</strong><br>{{videosSearchedErrors.message}}<br>-<br>{{videosSearchedErrors.solution}}</p>
@@ -194,8 +224,8 @@ function lvjm_import_videos_page() {
 										</div>
 										<transition name="fade">
 											<div v-show="videosCounter > 0" id="videos-found" class="col-xs-12 margin-top-10">
-												<div id="sticky-space" class="col-xs-12"></div>
-												<div id="videos-found-header" class="col-xs-12">
+                                                                                                <div id="sticky-space" class="col-xs-12"></div>
+                                                                                                <div id="videos-found-header" class="col-xs-12">
 													<h3><i class="fa" v-bind:class="[displayType == 'cards' ? 'fa-th' : 'fa-list-ul']"></i> 
 														<?php esc_html_e( 'Search results', 'lvjm_lang' ); ?> 
 														<template v-if="searchFromFeed">

--- a/wps-livejasmin.php
+++ b/wps-livejasmin.php
@@ -572,7 +572,8 @@ public function get_whitelabel_id_from_url( $url ) {
 				'check_least'             => esc_html__( 'Check at least 1 video', 'lvjm_lang' ),
 				'enable_button'           => esc_html__( 'to enable this button', 'lvjm_lang' ),
 				'import'                  => esc_html__( 'Import', 'lvjm_lang' ),
-				'search_feed'             => esc_html__( 'videos and save this search as a Feed. All your Feeds are displayed at the bottom of this page.', 'lvjm_lang' ),
+                                'search_feed'             => esc_html__( 'videos and save this search as a Feed. All your Feeds are displayed at the bottom of this page.', 'lvjm_lang' ),
+                                'all_categories'          => esc_html__( 'All Categories', 'lvjm_lang' ),
 			);
 		}
 


### PR DESCRIPTION
## Summary
- sanitize constructor logging in `LVJM_Search_Videos` and remove a duplicate API call
- surface the multi-category performer summary panel even when no videos are returned so the ✅/❌ statuses are always visible

## Testing
- php -l admin/class/class-lvjm-search-videos.php
- php -l admin/pages/page-import-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68da2360a7108324b9d964c2ebcdffe7