### PR TITLE
Implement performer search category scanning

### DIFF
--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -64,13 +64,34 @@ class LVJM_Search_Videos {
 	 */
 	private $videos;
 
-	/**
-	 * The searched_data.
-	 *
-	 * @var array $searched_data
-	 * @access private
-	 */
-	private $searched_data;
+        /**
+         * The searched_data.
+         *
+         * @var array $searched_data
+         * @access private
+         */
+        private $searched_data;
+
+        /**
+         * Performer filters provided by the user.
+         *
+         * @var array
+         */
+        private $performer_terms = array();
+
+        /**
+         * Normalized performer names for matching.
+         *
+         * @var array
+         */
+        private $normalized_performers = array();
+
+        /**
+         * Number of matches found per performer.
+         *
+         * @var array
+         */
+        private $performer_match_counts = array();
 
 	/**
 	 * The wp_version.
@@ -104,10 +125,15 @@ class LVJM_Search_Videos {
 	 * @param array $params The params needed to make the search.
 	 * @return void
 	 */
-	public function __construct( $params ) {
+        public function __construct( $params ) {
                 global $wp_version;
                 $this->wp_version = $wp_version;
                 $this->params     = $params;
+                if ( isset( $this->params['performer_list'] ) ) {
+                        $this->set_performer_terms( $this->params['performer_list'] );
+                } elseif ( isset( $this->params['performer'] ) && '' !== $this->params['performer'] ) {
+                        $this->set_performer_terms( array( $this->params['performer'] ) );
+                }
                 error_log( '[WPS-LiveJasmin] class-lvjm-search-videos.php constructor called' );
                 $cat_s_log = isset( $this->params['cat_s'] ) ? print_r( $this->params['cat_s'], true ) : '(unset)';
                 error_log( '[WPS-LiveJasmin] Search Param cat_s: ' . $cat_s_log );
@@ -165,12 +191,6 @@ class LVJM_Search_Videos {
             ],
             $this->feed_url
         );
-
-        // Append performer filter if provided
-        if ( isset($this->params['performer']) && !empty($this->params['performer']) ) {
-            $name = urlencode($this->params['performer']);
-            $this->feed_url .= '&forcedPerformers[]=' . $name;
-        }
 
 					if ( ! $this->feed_url ) {
 						WPSCORE()->write_log( 'error', 'Connection to Partner\'s API failed (feed url: <code>' . $this->feed_url . '</code> partner id: <code>:' . $this->params['partner']['id'] . '</code>)', __FILE__, __LINE__ );
@@ -255,50 +275,135 @@ class LVJM_Search_Videos {
 	 *
 	 * @return string The feed url with orientation.
 	 */
-	private function get_feed_url_with_orientation() {
-		$parsed_url = wp_parse_url( $this->feed_url );
-		parse_str( $parsed_url['query'], $old_query );
-		$new_query = array();
-		foreach ( $old_query as $key => $value ) {
-			if ( 'tags' !== $key ) {
-				$new_query[ $key ] = $value;
-				continue;
-			}
-			$new_query['tags']              = $value;
-			$new_query['sexualOrientation'] = 'straight';
-			if ( strpos( $value, 'gay' ) !== false ) {
-				$new_query[ $key ]              = trim( str_replace( 'gay', '', $value ) );
-				$new_query['sexualOrientation'] = 'gay';
-			}
-			if ( strpos( $value, 'shemale' ) !== false ) {
-				$new_query[ $key ]              = trim( str_replace( 'shemale', '', $value ) );
-				$new_query['sexualOrientation'] = 'shemale';
-			}
-		}
-		$parsed_url['query'] = http_build_query( $new_query );
-		$feed_url            = $this->unparse_url( $parsed_url );
-		return $feed_url;
-	}
+        private function get_feed_url_with_orientation() {
+                $parsed_url = wp_parse_url( $this->feed_url );
+                $query_args = array();
+                if ( isset( $parsed_url['query'] ) ) {
+                        parse_str( $parsed_url['query'], $query_args );
+                }
 
-	/**
-	 * Unparse a parsed url.
-	 *
-	 * @param array $parsed_url The parsed url.
-	 *
-	 * @return string The unparsed url.
-	 */
-	private function unparse_url( $parsed_url ) {
-		$scheme   = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '';
-		$host     = isset( $parsed_url['host'] ) ? $parsed_url['host'] : '';
-		$port     = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
-		$user     = isset( $parsed_url['user'] ) ? $parsed_url['user'] : '';
-		$pass     = isset( $parsed_url['pass'] ) ? ':' . $parsed_url['pass'] : '';
-		$pass     = ( $user || $pass ) ? "$pass@" : '';
-		$path     = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
-		$query    = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
-		$fragment = isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '';
-		return "$scheme$user$pass$host$port$path$query$fragment";
-	}
+                if ( isset( $this->params['cat_s'] ) && '' !== $this->params['cat_s'] ) {
+                        $query_args['tags'] = $this->params['cat_s'];
+                }
+
+                if ( isset( $query_args['tags'] ) ) {
+                        $safe_tags = str_ireplace( array( 'gay', 'shemale', 'trans' ), '', (string) $query_args['tags'] );
+                        $query_args['tags'] = trim( $safe_tags );
+                }
+
+                $query_args['sexualOrientation'] = 'straight';
+
+                $parsed_url['query'] = http_build_query( $query_args );
+                $feed_url            = $this->unparse_url( $parsed_url );
+                return $feed_url;
+        }
+
+        /**
+         * Unparse a parsed url.
+         *
+         * @param array $parsed_url The parsed url.
+         *
+         * @return string The unparsed url.
+         */
+        private function unparse_url( $parsed_url ) {
+                $scheme   = isset( $parsed_url['scheme'] ) ? $parsed_url['scheme'] . '://' : '';
+                $host     = isset( $parsed_url['host'] ) ? $parsed_url['host'] : '';
+                $port     = isset( $parsed_url['port'] ) ? ':' . $parsed_url['port'] : '';
+                $user     = isset( $parsed_url['user'] ) ? $parsed_url['user'] : '';
+                $pass     = isset( $parsed_url['pass'] ) ? ':' . $parsed_url['pass'] : '';
+                $pass     = ( $user || $pass ) ? "$pass@" : '';
+                $path     = isset( $parsed_url['path'] ) ? $parsed_url['path'] : '';
+                $query    = isset( $parsed_url['query'] ) ? '?' . $parsed_url['query'] : '';
+                $fragment = isset( $parsed_url['fragment'] ) ? '#' . $parsed_url['fragment'] : '';
+                return "$scheme$user$pass$host$port$path$query$fragment";
+        }
+
+        /**
+         * Normalise a performer name for comparisons.
+         *
+         * @param string $name Performer name.
+         * @return string
+         */
+        private function normalize_performer_name( $name ) {
+                $normalized = strtolower( preg_replace( '/[^a-z0-9]+/i', '', (string) $name ) );
+                return $normalized;
+        }
+
+        /**
+         * Store performer filters for the current search.
+         *
+         * @param array $terms Performer terms.
+         * @return void
+         */
+        private function set_performer_terms( $terms ) {
+                $terms                       = array_filter( array_map( 'trim', (array) $terms ) );
+                $this->performer_terms       = array_values( $terms );
+                $this->normalized_performers = array();
+                $this->performer_match_counts = array();
+                foreach ( $this->performer_terms as $term ) {
+                        $normalized = $this->normalize_performer_name( $term );
+                        if ( '' === $normalized ) {
+                                continue;
+                        }
+                        $this->normalized_performers[ $normalized ] = $term;
+                        if ( ! isset( $this->performer_match_counts[ $term ] ) ) {
+                                $this->performer_match_counts[ $term ] = 0;
+                        }
+                }
+        }
+
+        /**
+         * Extract performer names from a video payload.
+         *
+         * @param array|object $video Video payload.
+         * @return array
+         */
+        private function get_video_performer_names( $video ) {
+                $names = array();
+                if ( is_object( $video ) && isset( $video->performers ) ) {
+                        $names = (array) $video->performers;
+                } elseif ( is_array( $video ) && isset( $video['performers'] ) ) {
+                        $names = (array) $video['performers'];
+                } elseif ( is_array( $video ) && isset( $video['performerNames'] ) ) {
+                        $names = (array) $video['performerNames'];
+                }
+
+                $names = array_filter( array_map( 'strval', $names ) );
+                return $names;
+        }
+
+        /**
+         * Determine which performer terms match the provided video payload.
+         *
+         * @param array|object $video Video payload.
+         * @return array Array of matched performer display names.
+         */
+        private function find_matching_performers( $video ) {
+                if ( empty( $this->normalized_performers ) ) {
+                        return $this->performer_terms;
+                }
+
+                $matches   = array();
+                $videoList = $this->get_video_performer_names( $video );
+                foreach ( $videoList as $candidate ) {
+                        $normalized = $this->normalize_performer_name( $candidate );
+                        if ( isset( $this->normalized_performers[ $normalized ] ) ) {
+                                $display               = $this->normalized_performers[ $normalized ];
+                                $matches[ $display ] = $display;
+                        }
+                }
+
+                return array_values( $matches );
+        }
+
+        /**
+         * Retrieve performer match counts recorded during the search.
+         *
+         * @return array
+         */
+        public function get_performer_match_counts() {
+                return $this->performer_match_counts;
+        }
 
 	/**
 	 * Find videos from a json feed.
@@ -399,21 +504,37 @@ class LVJM_Search_Videos {
 				$current_item           = 0;
 				$page_end               = false;
 			}
-			while ( false === $page_end ) {
-				$feed_item = new LVJM_Json_Item( $array_feed[ $current_item ] );
-				$feed_item->init( $this->params, $this->feed_infos );
-				if ( $feed_item->is_valid() ) {
-					if ( ! in_array( $feed_item->get_id(), (array) $existing_ids['partner_all_videos_ids'], true ) ) {
-						$array_valid_videos[] = (array) $feed_item->get_data_for_json( $count_valid_feed_items );
-						$videos_details[]     = array(
-							'id'       => $feed_item->get_id(),
-							'response' => 'Success',
-						);
-						++$counters['valid_videos'];
-						++$count_valid_feed_items;
-					} elseif ( in_array( $feed_item->get_id(), (array) $existing_ids['partner_existing_videos_ids'], true ) ) {
-							$videos_details[] = array(
-								'id'       => $feed_item->get_id(),
+                        while ( false === $page_end ) {
+                                $raw_item  = $array_feed[ $current_item ];
+                                $matches   = $this->find_matching_performers( $raw_item );
+                                if ( ! empty( $this->normalized_performers ) && empty( $matches ) ) {
+                                        if ( $current_item >= ( $count_total_feed_items - 1 ) ) {
+                                                $page_end = true;
+                                                ++$current_page;
+                                        }
+                                        ++$current_item;
+                                        continue;
+                                }
+
+                                $feed_item = new LVJM_Json_Item( $raw_item );
+                                $feed_item->init( $this->params, $this->feed_infos );
+                                if ( $feed_item->is_valid() ) {
+                                        if ( ! in_array( $feed_item->get_id(), (array) $existing_ids['partner_all_videos_ids'], true ) ) {
+                                                $array_valid_videos[] = (array) $feed_item->get_data_for_json( $count_valid_feed_items );
+                                                $videos_details[]     = array(
+                                                        'id'       => $feed_item->get_id(),
+                                                        'response' => 'Success',
+                                                );
+                                                foreach ( (array) $matches as $matched_name ) {
+                                                        if ( isset( $this->performer_match_counts[ $matched_name ] ) ) {
+                                                                ++$this->performer_match_counts[ $matched_name ];
+                                                        }
+                                                }
+                                                ++$counters['valid_videos'];
+                                                ++$count_valid_feed_items;
+                                        } elseif ( in_array( $feed_item->get_id(), (array) $existing_ids['partner_existing_videos_ids'], true ) ) {
+                                                        $videos_details[] = array(
+                                                                'id'       => $feed_item->get_id(),
 								'response' => 'Already imported',
 							);
 							++$counters['existing_videos'];

--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -110,6 +110,20 @@ function LVJM_pageImportVideos() {
                 videosHasBeenSearched: false,
                 videosSearchedErrors: {},
                 searchedData: {},
+                performerSearchMode: false,
+                searchProgress: {
+                    currentCategory: '',
+                    currentPerformer: '',
+                    videosFound: 0
+                },
+                categoryQueue: [],
+                currentCategoryIndex: 0,
+                foundVideoIds: [],
+                noPerformerVideos: [],
+                multiCategorySummary: [],
+                multiCategorySummaryIndex: {},
+                performerList: [],
+                progressiveSearchParams: {},
 
                 currentVideo: '',
                 currentVideoUrl: '',
@@ -260,6 +274,9 @@ function LVJM_pageImportVideos() {
                     return this.videos.length;
                 },
                 performerReports: function () {
+                    if (Array.isArray(this.multiCategorySummary) && this.multiCategorySummary.length) {
+                        return this.multiCategorySummary;
+                    }
                     if (!this.searchedData || !this.searchedData.multi_category) {
                         return [];
                     }
@@ -339,9 +356,245 @@ function LVJM_pageImportVideos() {
                 }
             },
             methods: {
+                parsePerformerInput: function (raw) {
+                    if (!raw) {
+                        return [];
+                    }
+                    var parsed = raw.split(/[\n,]+/).map(function (name) {
+                        return name.trim();
+                    }).filter(function (name) {
+                        return name.length > 0;
+                    });
+                    return lodash.uniq(parsed);
+                },
+                getStraightCategories: function () {
+                    var categories = [];
+                    (this.partnerCats || []).forEach(function (cat) {
+                        if (!cat) {
+                            return;
+                        }
+                        if (cat.id === 'optgroup') {
+                            if (cat.name && cat.name.toLowerCase() === 'straight' && Array.isArray(cat.sub_cats)) {
+                                cat.sub_cats.forEach(function (subCat) {
+                                    if (!subCat || !subCat.id) {
+                                        return;
+                                    }
+                                    var id = subCat.id.toString().toLowerCase();
+                                    if (id.indexOf('gay') !== -1 || id.indexOf('shemale') !== -1 || id.indexOf('trans') !== -1) {
+                                        return;
+                                    }
+                                    categories.push({
+                                        id: subCat.id,
+                                        name: subCat.name || subCat.id
+                                    });
+                                });
+                            }
+                            return;
+                        }
+                        if (!cat.id || cat.id === 'all_categories') {
+                            return;
+                        }
+                        var candidate = cat.id.toString().toLowerCase();
+                        if (candidate.indexOf('gay') !== -1 || candidate.indexOf('shemale') !== -1 || candidate.indexOf('trans') !== -1) {
+                            return;
+                        }
+                        categories.push({
+                            id: cat.id,
+                            name: cat.name || cat.id
+                        });
+                    });
+                    return lodash.sortBy(categories, function (item) {
+                        return item.name.toLowerCase();
+                    });
+                },
+                resetPerformerSearchState: function () {
+                    this.performerSearchMode = false;
+                    this.searchProgress.currentCategory = '';
+                    this.searchProgress.currentPerformer = '';
+                    this.searchProgress.videosFound = 0;
+                    this.categoryQueue = [];
+                    this.currentCategoryIndex = 0;
+                    this.foundVideoIds = [];
+                    this.noPerformerVideos = [];
+                    this.multiCategorySummary = [];
+                    this.multiCategorySummaryIndex = {};
+                    this.performerList = [];
+                    this.progressiveSearchParams = {};
+                },
+                formatVideoForList: function (video) {
+                    return {
+                        id: video.id,
+                        title: video.title,
+                        thumb_url: video.thumb_url,
+                        thumbs_urls: video.thumbs_urls,
+                        trailer_url: video.trailer_url,
+                        desc: video.desc,
+                        embed: video.embed,
+                        tracking_url: video.tracking_url,
+                        duration: video.duration,
+                        quality: video.quality,
+                        isHd: video.isHd,
+                        uploader: video.uploader,
+                        actors: video.actors,
+                        tags: video.tags,
+                        video_url: video.video_url,
+                        checked: video.checked,
+                        grabbed: false,
+                        loading: {
+                            removing: false
+                        }
+                    };
+                },
+                addVideosFromResponse: function (videos) {
+                    var self = this;
+                    if (!Array.isArray(videos)) {
+                        return;
+                    }
+                    videos.forEach(function (video) {
+                        if (!video || !video.id) {
+                            return;
+                        }
+                        if (self.foundVideoIds.indexOf(video.id) !== -1) {
+                            return;
+                        }
+                        self.foundVideoIds.push(video.id);
+                        self.videos.push(self.formatVideoForList(video));
+                    });
+                },
+                startPerformerSearch: function (options) {
+                    this.resetPerformerSearchState();
+                    this.performerSearchMode = true;
+                    this.performerList = options.performers;
+                    this.categoryQueue = this.getStraightCategories();
+                    this.currentCategoryIndex = 0;
+                    this.progressiveSearchParams = options;
+                    this.firstImport = options.method === 'create';
+                    this.searchProgress.currentPerformer = this.performerList.join(', ');
+                    this.searchProgress.videosFound = 0;
+                    var summary = [];
+                    var indexMap = {};
+                    var defaultLabel = this.data && this.data.objectL10n && this.data.objectL10n.no_performer_filter ? this.data.objectL10n.no_performer_filter : 'No performer filter';
+                    this.performerList.forEach(function (name, idx) {
+                        var display = name !== undefined && name !== null && name !== '' ? name : defaultLabel;
+                        summary.push({
+                            name: name,
+                            display_name: display,
+                            video_count: 0,
+                            status: false,
+                            category_reports: []
+                        });
+                        indexMap[name] = idx;
+                    });
+                    this.multiCategorySummary = summary;
+                    this.multiCategorySummaryIndex = indexMap;
+                    if (!this.categoryQueue.length) {
+                        this.finalizePerformerSearch();
+                        return;
+                    }
+                    this.processNextCategory();
+                },
+                processNextCategory: function () {
+                    var self = this;
+                    if (!this.performerSearchMode) {
+                        return;
+                    }
+                    if (this.currentCategoryIndex >= this.categoryQueue.length) {
+                        this.finalizePerformerSearch();
+                        return;
+                    }
+                    var category = this.categoryQueue[this.currentCategoryIndex];
+                    this.searchProgress.currentCategory = category.name;
+                    this.searchProgress.videosFound = this.foundVideoIds.length;
+                    var payload = {
+                        action: 'lvjm_search_videos',
+                        nonce: LVJM_import_videos.ajax.nonce,
+                        progressive: 1,
+                        category_id: category.id,
+                        category_name: category.name,
+                        performer: this.performerList.join(','),
+                        log_performer: this.performerList.join(', '),
+                        partner: this.progressiveSearchParams.partner,
+                        limit: this.progressiveSearchParams.limit,
+                        method: this.progressiveSearchParams.method,
+                        kw: this.progressiveSearchParams.kw,
+                        cat_s: this.progressiveSearchParams.cat_s,
+                        from: this.progressiveSearchParams.from,
+                        original_cat_s: this.progressiveSearchParams.original_cat_s,
+                        multi_category_search: 1
+                    };
+                    if (this.progressiveSearchParams.feed_id) {
+                        payload.feed_id = this.progressiveSearchParams.feed_id;
+                    }
+                    this.$http.post(
+                        LVJM_import_videos.ajax.url,
+                        payload,
+                        { emulateJSON: true }
+                    ).then(function (response) {
+                        if (response && response.body) {
+                            self.handleCategorySuccess(response.body, category);
+                        }
+                    }, function (response) {
+                        console.error(response);
+                    }).then(function () {
+                        self.currentCategoryIndex += 1;
+                        self.processNextCategory();
+                    });
+                },
+                handleCategorySuccess: function (data, category) {
+                    if (!data) {
+                        return;
+                    }
+                    this.addVideosFromResponse(data.videos || []);
+                    var matches = data.matches || {};
+                    var self = this;
+                    this.performerList.forEach(function (name) {
+                        var idx = self.multiCategorySummaryIndex[name];
+                        if (typeof idx === 'undefined') {
+                            return;
+                        }
+                        var summary = self.multiCategorySummary[idx];
+                        var count = matches[name] ? parseInt(matches[name], 10) : 0;
+                        if (isNaN(count)) {
+                            count = 0;
+                        }
+                        summary.video_count = (summary.video_count || 0) + count;
+                        summary.status = summary.video_count > 0;
+                        summary.category_reports.push({
+                            id: category.id,
+                            name: category.name,
+                            videos_found: count
+                        });
+                    });
+                    this.searchProgress.videosFound = this.foundVideoIds.length;
+                },
+                finalizePerformerSearch: function () {
+                    var self = this;
+                    this.performerSearchMode = false;
+                    this.videosHasBeenSearched = true;
+                    this.searchingVideos = false;
+                    this.searchProgress.currentCategory = '';
+                    this.searchProgress.currentPerformer = '';
+                    this.searchProgress.videosFound = this.foundVideoIds.length;
+                    this.searchedData = {
+                        multi_category: {
+                            performer_reports: this.multiCategorySummary
+                        }
+                    };
+                    this.noPerformerVideos = this.performerList.filter(function (name) {
+                        var idx = self.multiCategorySummaryIndex[name];
+                        if (typeof idx === 'undefined') {
+                            return false;
+                        }
+                        return parseInt(self.multiCategorySummary[idx].video_count, 10) === 0;
+                    });
+                    jQuery('[data-id="sort_partners"]').prop('disabled', false);
+                    jQuery('[data-id="cat_s_select"]').prop('disabled', false);
+                    jQuery('[data-id="partner_select"]').prop('disabled', false);
+                    stickNav();
+                },
                 loadPartnerCats: function () {
                     this.partnerCatsLoading = true;
-                    
+
                     this.$http.post(
     
                             LVJM_import_videos.ajax.url, {
@@ -409,7 +662,6 @@ function LVJM_pageImportVideos() {
 
                     var cat_s = '';
                     var kw = '';
-                    var partnerId = '';
                     var partner = null;
 
                     //reset searching states
@@ -418,6 +670,8 @@ function LVJM_pageImportVideos() {
                     this.videosHasBeenSearched = false;
                     this.videosSearchedErrors = {};
                     this.searchedData = {};
+                    this.resetPerformerSearchState();
+                    this.foundVideoIds = [];
 
                     if (feedId === undefined) {
 
@@ -459,10 +713,24 @@ function LVJM_pageImportVideos() {
                         this.searchFromFeed = true;
                     }
 
-                    //reset tooltips states
-                    //jQuery('[rel=tooltip]').tooltip('hide');
+                    var performerInput = this.parsePerformerInput(this.selectedPerformer);
+                    var usePerformerProgressive = performerInput.length > 0 && feedId === undefined;
 
-                    
+                    if (usePerformerProgressive) {
+                        this.startPerformerSearch({
+                            performers: performerInput,
+                            partner: partner,
+                            limit: this.data.videosLimit,
+                            method: method,
+                            kw: kw,
+                            cat_s: cat_s,
+                            from: 'manual',
+                            original_cat_s: cat_s.replace('&', '%%'),
+                            feed_id: feedId
+                        });
+                        return;
+                    }
+
                     this.$http.post(
 
                             LVJM_import_videos.ajax.url, {
@@ -474,7 +742,7 @@ function LVJM_pageImportVideos() {
                                 limit: this.data.videosLimit,
                                 method: method,
                                 nonce: LVJM_import_videos.ajax.nonce,
-                                multi_category_search: this.selectedCat === 'all_categories' ? 1 : 0,
+                                multi_category_search: (this.selectedCat === 'all_categories' || performerInput.length > 0) ? 1 : 0,
                                 original_cat_s: cat_s.replace('&', '%%'),
                                 partner: partner,
                                 performer: this.selectedPerformer
@@ -482,40 +750,12 @@ function LVJM_pageImportVideos() {
                                 emulateJSON: true
                             })
                         .then(function (response) {
-                            var videos = this.videos;
                             if (lodash.isEmpty(response.body.errors)) {
                                 this.searchedData = response.body.searched_data || {};
-                                lodash.each(response.body.videos, function (video) {
-                                    videos.push({
-                                        id: video.id,
-                                        title: video.title,
-                                        thumb_url: video.thumb_url,
-//                                        thumbs_urls: video.thumbs_urls.split(','),
-                                        thumbs_urls: video.thumbs_urls,
-                                        trailer_url: video.trailer_url,
-                                        desc: video.desc,
-                                        embed: video.embed,
-                                        tracking_url: video.tracking_url,
-                                        duration: video.duration,
-                                        quality: video.quality,
-                                        isHd: video.isHd,
-                                        uploader: video.uploader,
-                                        actors: video.actors,
-                                        tags: video.tags,
-                                        video_url: video.video_url,
-                                        checked: video.checked,
-                                        grabbed: false,
-                                        loading: {
-                                            removing: false
-                                        }
-                                    });
-                                });
+                                this.addVideosFromResponse(response.body.videos || []);
                             } else {
                                 this.videosSearchedErrors = response.body.errors;
                             }
-                            delete errors;
-                            delete response;
-                            delete videos;
                             if (method == 'create') {
                                 this.firstImport = true;
                             } else {

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -172,7 +172,18 @@ function lvjm_import_videos_page() {
 									<!-- / search videos block -->
 									<!-- results success block -->
                                                                         <div class="row">
-                                                                                                                                                                                                                                                <div v-if="performerReports.length" class="col-xs-12 margin-top-10">
+
+                                                                                                                <div v-if="performerSearchMode" class="col-xs-12">
+												<div v-if="searchingVideos" class="alert alert-info">
+														<p><?php esc_html_e( 'Currently searching category', 'lvjm_lang' ); ?>: {{ searchProgress.currentCategory || '...' }} <?php esc_html_e( 'for', 'lvjm_lang' ); ?> {{ searchProgress.currentPerformer || selectedPerformer }}</p>
+														<p><?php esc_html_e( 'Videos found so far', 'lvjm_lang' ); ?>: {{ searchProgress.videosFound }}</p>
+												</div>
+												<div v-if="!searchingVideos && noPerformerVideos.length" class="alert alert-warning">
+														<p v-for="(name, index) in noPerformerVideos" v-bind:key="index"><?php esc_html_e( 'No promo videos available for', 'lvjm_lang' ); ?> {{ name || (data.objectL10n && data.objectL10n.no_performer_filter ? data.objectL10n.no_performer_filter : '<?php esc_html_e( 'No performer filter', 'lvjm_lang' ); ?>') }} <?php esc_html_e( 'in straight categories.', 'lvjm_lang' ); ?></p>
+												</div>
+                                                                                                                </div>
+
+<div v-if="performerReports.length" class="col-xs-12 margin-top-10">
                                                                                         <h4 class="margin-top-0"><?php esc_html_e( 'All Categories search summary', 'lvjm_lang' ); ?></h4>
                                                                                         <div class="panel panel-default" v-for="(report, index) in performerReports" v-bind:key="index" style="margin-bottom:15px;">
                                                                                                 <div class="panel-heading clearfix">


### PR DESCRIPTION
## Summary
- add debug logging helper and progressive performer search handling in the AJAX controller
- expand the LiveJasmin search class to iterate categories, normalize performer names, and record match counts
- update the importer UI/UX to stream performer search progress and show status messages while results load

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da2dbf10a88324b196c0a78e506f13