### PR TITLE
Handle performer data when feeds expose models collections

### DIFF
--- a/admin/actions/ajax-search-videos.php
+++ b/admin/actions/ajax-search-videos.php
@@ -70,12 +70,22 @@ function lvjm_search_videos( $params = '' ) {
             return strtolower( preg_replace( '/[^a-z0-9]/', '', $name ) );
         };
         $extract_performer_set = static function ( $video ) {
-            $names = array();
+            $source = null;
 
-            if ( ! empty( $video['performers'] ) && is_array( $video['performers'] ) ) {
-                $names = $video['performers'];
-            } elseif ( ! empty( $video['models'] ) && is_array( $video['models'] ) ) {
-                $names = $video['models'];
+            if ( ! empty( $video['performers'] ) ) {
+                $source = $video['performers'];
+            } elseif ( ! empty( $video['models'] ) ) {
+                $source = $video['models'];
+            } else {
+                return array();
+            }
+
+            if ( is_array( $source ) ) {
+                $names = $source;
+            } elseif ( $source instanceof \Traversable ) {
+                $names = iterator_to_array( $source );
+            } elseif ( is_object( $source ) ) {
+                $names = $source;
             } else {
                 return array();
             }

--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -428,13 +428,20 @@ class LVJM_Search_Videos {
                         return array();
                 }
 
-                $names = array();
+                $names  = array();
+                $source = null;
 
-                if ( ! empty( $raw_feed_item['performers'] ) && is_array( $raw_feed_item['performers'] ) ) {
-                        $names = $this->sanitize_performer_source( $raw_feed_item['performers'] );
-                } elseif ( ! empty( $raw_feed_item['models'] ) && is_array( $raw_feed_item['models'] ) ) {
-                        $names = $this->sanitize_performer_source( $raw_feed_item['models'] );
+                if ( ! empty( $raw_feed_item['performers'] ) ) {
+                        $source = $raw_feed_item['performers'];
+                } elseif ( ! empty( $raw_feed_item['models'] ) ) {
+                        $source = $raw_feed_item['models'];
                 }
+
+                if ( null === $source ) {
+                        return array();
+                }
+
+                $names = $this->sanitize_performer_source( $source );
 
                 if ( empty( $names ) ) {
                         return array();
@@ -452,10 +459,18 @@ class LVJM_Search_Videos {
         private function sanitize_performer_source( $source ) {
                 $names = array();
 
-                if ( isset( $source['data'] ) && is_array( $source['data'] ) ) {
-                        $source = $source['data'];
-                } elseif ( is_object( $source ) && isset( $source->data ) && is_array( $source->data ) ) {
-                        $source = $source->data;
+                if ( is_array( $source ) ) {
+                        if ( isset( $source['data'] ) && is_array( $source['data'] ) ) {
+                                $source = $source['data'];
+                        }
+                } elseif ( is_object( $source ) ) {
+                        if ( isset( $source->data ) && is_array( $source->data ) ) {
+                                $source = $source->data;
+                        } elseif ( $source instanceof \Traversable ) {
+                                $source = iterator_to_array( $source );
+                        } else {
+                                $source = (array) $source;
+                        }
                 } elseif ( $source instanceof \Traversable ) {
                         $source = iterator_to_array( $source );
                 }


### PR DESCRIPTION
## Summary
- normalize AJAX performer extraction to fall back to `models` payloads and handle traversable sources
- allow the search class to sanitize performer data from either `performers` or `models` collections before matching

## Testing
- php -l admin/actions/ajax-search-videos.php
- php -l admin/class/class-lvjm-search-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68da5e3a92188324af62a09c8052c809