### PR TITLE
Fix performer matching for feeds providing models array

### DIFF
--- a/admin/actions/ajax-search-videos.php
+++ b/admin/actions/ajax-search-videos.php
@@ -70,23 +70,25 @@ function lvjm_search_videos( $params = '' ) {
             return strtolower( preg_replace( '/[^a-z0-9]/', '', $name ) );
         };
         $extract_performer_set = static function ( $video ) {
-            $source = null;
+            $names = array();
 
             if ( ! empty( $video['performers'] ) ) {
-                $source = $video['performers'];
-            } elseif ( ! empty( $video['models'] ) ) {
-                $source = $video['models'];
-            } else {
-                return array();
+                if ( is_array( $video['performers'] ) ) {
+                    $names = $video['performers'];
+                } elseif ( $video['performers'] instanceof \Traversable ) {
+                    $names = iterator_to_array( $video['performers'] );
+                }
             }
 
-            if ( is_array( $source ) ) {
-                $names = $source;
-            } elseif ( $source instanceof \Traversable ) {
-                $names = iterator_to_array( $source );
-            } elseif ( is_object( $source ) ) {
-                $names = $source;
-            } else {
+            if ( empty( $names ) && ! empty( $video['models'] ) ) {
+                if ( is_array( $video['models'] ) ) {
+                    $names = $video['models'];
+                } elseif ( $video['models'] instanceof \Traversable ) {
+                    $names = iterator_to_array( $video['models'] );
+                }
+            }
+
+            if ( empty( $names ) || ! is_array( $names ) ) {
                 return array();
             }
 

--- a/admin/class/class-lvjm-search-videos.php
+++ b/admin/class/class-lvjm-search-videos.php
@@ -428,20 +428,29 @@ class LVJM_Search_Videos {
                         return array();
                 }
 
-                $names  = array();
-                $source = null;
+                $names = array();
 
                 if ( ! empty( $raw_feed_item['performers'] ) ) {
-                        $source = $raw_feed_item['performers'];
-                } elseif ( ! empty( $raw_feed_item['models'] ) ) {
-                        $source = $raw_feed_item['models'];
+                        if ( is_array( $raw_feed_item['performers'] ) ) {
+                                $names = $raw_feed_item['performers'];
+                        } elseif ( $raw_feed_item['performers'] instanceof \Traversable ) {
+                                $names = iterator_to_array( $raw_feed_item['performers'] );
+                        }
                 }
 
-                if ( null === $source ) {
+                if ( empty( $names ) && ! empty( $raw_feed_item['models'] ) ) {
+                        if ( is_array( $raw_feed_item['models'] ) ) {
+                                $names = $raw_feed_item['models'];
+                        } elseif ( $raw_feed_item['models'] instanceof \Traversable ) {
+                                $names = iterator_to_array( $raw_feed_item['models'] );
+                        }
+                }
+
+                if ( empty( $names ) || ! is_array( $names ) ) {
                         return array();
                 }
 
-                $names = $this->sanitize_performer_source( $source );
+                $names = $this->sanitize_performer_source( $names );
 
                 if ( empty( $names ) ) {
                         return array();


### PR DESCRIPTION
## Summary
- guard ajax performer filtering against missing performer arrays by normalizing to arrays from performers or models
- update search helper to consider the models collection when building performer candidates, preventing empty match results

## Testing
- php -l admin/actions/ajax-search-videos.php
- php -l admin/class/class-lvjm-search-videos.php

------
https://chatgpt.com/codex/tasks/task_e_68da608f2ba48324a166c4df3c431704