### PR TITLE
Add deep search mode and auto model profiles

### DIFF
--- a/admin/actions/ajax-search-videos.php
+++ b/admin/actions/ajax-search-videos.php
@@ -13,6 +13,95 @@ function lvjm_search_videos( $params = '' ) {
     }
 
     $errors = array();
+    $searched_data = array();
+
+    $normalize_performer = static function ( $name ) {
+        $name = (string) $name;
+
+        return strtolower( preg_replace( '/[^a-z0-9]/', '', $name ) );
+    };
+
+    $extract_performer_set = static function ( $video ) {
+        $names = array();
+
+        if ( ! empty( $video['performers'] ) ) {
+            if ( is_array( $video['performers'] ) ) {
+                $names = $video['performers'];
+            } elseif ( $video['performers'] instanceof \Traversable ) {
+                $names = iterator_to_array( $video['performers'] );
+            }
+        }
+
+        if ( empty( $names ) && ! empty( $video['models'] ) ) {
+            if ( is_array( $video['models'] ) ) {
+                $names = $video['models'];
+            } elseif ( $video['models'] instanceof \Traversable ) {
+                $names = iterator_to_array( $video['models'] );
+            }
+        }
+
+        if ( empty( $names ) && ! empty( $video['lvjm_performer_candidates'] ) && is_array( $video['lvjm_performer_candidates'] ) ) {
+            $names = $video['lvjm_performer_candidates'];
+        }
+
+        if ( empty( $names ) || ! is_array( $names ) ) {
+            $actors = isset( $video['actors'] ) ? (string) $video['actors'] : '';
+            if ( '' !== $actors ) {
+                $names = array_map( 'trim', explode( ',', $actors ) );
+            }
+        }
+
+        if ( empty( $names ) || ! is_array( $names ) ) {
+            return array();
+        }
+
+        if ( isset( $names['data'] ) && is_array( $names['data'] ) ) {
+            $names = $names['data'];
+        } elseif ( is_object( $names ) && isset( $names->data ) && is_array( $names->data ) ) {
+            $names = $names->data;
+        } elseif ( $names instanceof \Traversable ) {
+            $names = iterator_to_array( $names );
+        }
+
+        if ( empty( $names ) || ! is_array( $names ) ) {
+            return array();
+        }
+
+        $collected = array();
+        foreach ( $names as $entry ) {
+            $value = '';
+            if ( is_array( $entry ) ) {
+                $keys = array( 'name', 'displayName', 'username', 'id' );
+                foreach ( $keys as $key ) {
+                    if ( isset( $entry[ $key ] ) && '' !== (string) $entry[ $key ] ) {
+                        $value = (string) $entry[ $key ];
+                        break;
+                    }
+                }
+            } elseif ( is_object( $entry ) ) {
+                $keys = array( 'name', 'displayName', 'username', 'id' );
+                foreach ( $keys as $key ) {
+                    if ( isset( $entry->$key ) && '' !== (string) $entry->$key ) {
+                        $value = (string) $entry->$key;
+                        break;
+                    }
+                }
+            } else {
+                $value = (string) $entry;
+            }
+
+            $value = trim( $value );
+            if ( '' !== $value ) {
+                $collected[] = $value;
+            }
+        }
+
+        if ( empty( $collected ) ) {
+            return array();
+        }
+
+        return array_values( array_unique( $collected ) );
+    };
     // Force brutal loop if All Straight Categories is chosen
     if ( isset($params['cat_s']) && $params['cat_s'] === 'all_straight' ) {
         $params['multi_category_search'] = '1';
@@ -21,9 +110,139 @@ function lvjm_search_videos( $params = '' ) {
     $videos = array();
 
     $is_multi_straight = isset($params['multi_category_search']) && $params['multi_category_search'] === '1';
-    $performer = isset($params['performer']) ? sanitize_text_field((string)$params['performer']) : '';
+    $performer   = isset( $params['performer'] ) ? sanitize_text_field( (string) $params['performer'] ) : '';
+    $deep_search = isset( $params['deep_search'] ) && '1' === (string) $params['deep_search'];
+    $search_name = '';
+    if ( $deep_search ) {
+        $search_name = isset( $params['search_name'] ) ? sanitize_text_field( (string) $params['search_name'] ) : '';
+        $performer   = '';
+    }
 
-    if ( $is_multi_straight ) {
+    if ( $deep_search ) {
+        $limit = isset( $params['limit'] ) ? (int) $params['limit'] : 60;
+        if ( $limit <= 0 ) {
+            $limit = 60;
+        }
+
+        if ( '' === $search_name ) {
+            $errors = array(
+                'code'     => 'deep_search_missing_name',
+                'message'  => __( 'Deep Search requires a performer or model name.', 'lvjm_lang' ),
+                'solution' => __( 'Enter a name and try again.', 'lvjm_lang' ),
+            );
+        } else {
+            $normalized_target = $normalize_performer( $search_name );
+
+            $available_categories = LVJM()->get_ordered_categories();
+            $straight_categories  = array();
+
+            foreach ( (array) $available_categories as $category_entry ) {
+                if ( ! isset( $category_entry['id'] ) ) {
+                    continue;
+                }
+
+                if ( 'optgroup' === $category_entry['id'] ) {
+                    if ( isset( $category_entry['name'] ) && 0 === strcasecmp( (string) $category_entry['name'], 'Straight' ) ) {
+                        foreach ( (array) $category_entry['sub_cats'] as $sub_cat ) {
+                            if ( empty( $sub_cat['id'] ) ) {
+                                continue;
+                            }
+                            $straight_categories[ (string) $sub_cat['id'] ] = isset( $sub_cat['name'] ) ? (string) $sub_cat['name'] : (string) $sub_cat['id'];
+                        }
+                    }
+                    continue;
+                }
+
+                $id    = (string) $category_entry['id'];
+                $label = isset( $category_entry['name'] ) ? (string) $category_entry['name'] : $id;
+                $haystack = strtolower( $id . ' ' . $label );
+                if ( false !== strpos( $haystack, 'gay' ) || false !== strpos( $haystack, 'shemale' ) || false !== strpos( $haystack, 'trans' ) || false !== strpos( $haystack, 'ladyboy' ) ) {
+                    continue;
+                }
+                $straight_categories[ $id ] = $label;
+            }
+
+            $videos            = array();
+            $deep_summary      = array();
+            $base_params       = $params;
+            unset( $base_params['performer'] );
+            $base_params['include_existing'] = true;
+            $seen_video_ids    = array();
+
+            foreach ( $straight_categories as $cat_id => $cat_label ) {
+                if ( count( $videos ) >= $limit ) {
+                    break;
+                }
+
+                $tag_params            = $base_params;
+                $tag_params['category'] = $cat_id;
+                $tag_params['cat_s']    = $cat_id;
+                $remaining_limit        = $limit - count( $videos );
+                $tag_params['limit']    = $remaining_limit > 60 ? 60 : max( 1, $remaining_limit );
+
+                $search_videos = new LVJM_Search_Videos( $tag_params );
+
+                if ( $search_videos->has_errors() ) {
+                    continue;
+                }
+
+                $tag_matches = array();
+                foreach ( (array) $search_videos->get_videos() as $video ) {
+                    $candidates = $extract_performer_set( $video );
+
+                    if ( empty( $candidates ) ) {
+                        continue;
+                    }
+
+                    $matched = false;
+                    foreach ( $candidates as $candidate ) {
+                        if ( $normalize_performer( $candidate ) === $normalized_target ) {
+                            $matched = true;
+                            break;
+                        }
+                    }
+
+                    if ( ! $matched ) {
+                        continue;
+                    }
+
+                    $video_id = isset( $video['id'] ) ? (string) $video['id'] : '';
+
+                    if ( '' !== $video_id && isset( $seen_video_ids[ $video_id ] ) ) {
+                        continue;
+                    }
+
+                    if ( '' !== $video_id ) {
+                        $seen_video_ids[ $video_id ] = true;
+                    }
+
+                    $video['source_tag'] = $cat_label;
+                    $videos[]            = $video;
+                    $tag_matches[]       = $video;
+
+                    if ( count( $videos ) >= $limit ) {
+                        break;
+                    }
+                }
+
+                $matched_count = count( $tag_matches );
+                error_log( sprintf( '[WPS-LiveJasmin] Search name: %s | Tag: %s | Videos matched: %d', $search_name, $cat_label, $matched_count ) );
+
+                if ( $matched_count > 0 ) {
+                    $deep_summary[] = array(
+                        'name'  => $search_name,
+                        'tag'   => $cat_label,
+                        'count' => $matched_count,
+                    );
+                }
+            }
+
+            $searched_data = array(
+                'deep_summary' => $deep_summary,
+                'search_name'  => $search_name,
+            );
+        }
+    } elseif ( $is_multi_straight ) {
         $straight_categories = ['69', 'Above Average', 'Amateur', 'Anal', 'Angry', 'Asian', 'Ass', 'Ass To mouth', 'Athletic', 'Auburn Hair', 'Babe', 'Bald', 'Ball Sucking', 'Bathroom', 'Bbc', 'BBW', 'Bdsm', 'Bed', 'Big Ass', 'Big Boobs', 'Big Booty', 'Big Breasts', 'Big Cock', 'Big Tists', 'Bizarre', 'Black Eyes', 'Black Girl', 'Black Hair', 'Blonde', 'Blond Hair', 'Blowjob', 'Blue Eyes', 'Blue Hair', 'Bondage', 'Boots', 'Booty', 'Bossy', 'Brown Eyes', 'Brown Hair', 'Brunette', 'Butt Plug', 'Cam Girl', 'Cam Porn', 'Cameltoe', 'Celebrity', 'Cfnm', 'Cheerleader', 'Clown Hair', 'Cock', 'College Girl', 'Cop', 'Cosplay', 'Cougar', 'Couple', 'Cowgirl', 'Creampie', 'Crew Cut', 'Cum', 'Cum On Tits', 'Cumshot', 'Curious', 'Cut', 'Cute', 'Dance', 'Deepthroat', 'Dilde', 'Dirty', 'Doctor', 'Doggy', 'Domination', 'Double Penetration', 'Ebony', 'Erotic', 'Eye Contact', 'Facesitting', 'Facial', 'Fake Tits', 'Fat Ass', 'Fetish', 'Fingering', 'Fire Red Hair', 'Fishnet', 'Fisting', 'Flirting', 'Foot Sex', 'Footjob', 'Fuck', 'Gag', 'Gaping', 'Gilf', 'Girl', 'Glamour', 'Glasses', 'Green Eyes', 'Grey Eyes', 'Group', 'Gym', 'Hairy', 'Handjob', 'Hard Cock', 'Hd', 'High Heels', 'Homemade', 'Homy', 'Hot', 'Hot Flirt', 'Housewife', 'Huge Cock', 'Huge Tits', 'Innocent', 'Interracial', 'Intim Piercing', 'Jeans', 'Kitchen', 'Ladyboy', 'Large Build', 'Latex', 'Latin', 'Latina', 'Leather', 'Lesbian', 'Lick', 'Lingerie', 'Live Sex', 'Long Hair', 'Long Nails', 'Machine', 'Maid', 'Massage', 'Masturbation', 'Mature', 'Milf', 'Missionary', 'Misstress', 'Moaning', 'Muscular', 'Muslim', 'Naked', 'Nasty', 'Natural Tits', 'Normal Cock', 'Normal Tits', 'Nurse', 'Nylon', 'Office', 'Oiled', 'Orange Hair', 'Orgasm', 'Orgy', 'Outdoor', 'Party', 'Pawg', 'Petite', 'Piercing', 'Pink Hair', 'Pissing', 'Pool', 'Pov', 'Pregnant', 'Princess', 'Public', 'punish', 'Pussy', 'Pvc', 'Quicky', 'Redhead', 'Remote Toy', 'Reverse Cowgirl', 'Riding', 'Rimjob', 'Roleplay', 'Romantic', 'Room', 'Rough', 'Schoolgirl', 'Scissoring', 'Scream', 'Secretary', 'Sensual', 'Sextoy', 'Sexy', 'Shaved', 'Short Girl', 'Short Hair', 'Shoulder Lenght Hair', 'Shy', 'Skinny', 'Slave', 'Sloppy', 'Slutty', 'Small Ass', 'Small Cock', 'Smoking', 'Solo', 'Sologirl', 'squirt', 'Stockings', 'Strap On', 'Stretching', 'Striptease', 'Stroking', 'Suck', 'Swallow', 'Tall', 'Tattoo', 'Teacher', 'Teasing', 'Teen', 'Treesome', 'Tight', 'Tiny Tits', 'Titjob', 'Toy', 'Trimmed', 'Uniform', 'Virgin', 'Watching', 'Wet', 'White', 'Lesbian'];
 
         $seen_ids = array();
@@ -58,88 +277,13 @@ function lvjm_search_videos( $params = '' ) {
         $search_videos = new LVJM_Search_Videos( $params );
         if ( ! $search_videos->has_errors() ) {
             $videos = $search_videos->get_videos();
+            $searched_data = $search_videos->get_searched_data();
         }
     }
 
     // Performer filtering
-    if ( '' !== $performer ) {
+    if ( '' !== $performer && ! $deep_search ) {
         $filtered              = array();
-        $normalize_performer   = static function ( $name ) {
-            $name = (string) $name;
-
-            return strtolower( preg_replace( '/[^a-z0-9]/', '', $name ) );
-        };
-        $extract_performer_set = static function ( $video ) {
-            $names = array();
-
-            if ( ! empty( $video['performers'] ) ) {
-                if ( is_array( $video['performers'] ) ) {
-                    $names = $video['performers'];
-                } elseif ( $video['performers'] instanceof \Traversable ) {
-                    $names = iterator_to_array( $video['performers'] );
-                }
-            }
-
-            if ( empty( $names ) && ! empty( $video['models'] ) ) {
-                if ( is_array( $video['models'] ) ) {
-                    $names = $video['models'];
-                } elseif ( $video['models'] instanceof \Traversable ) {
-                    $names = iterator_to_array( $video['models'] );
-                }
-            }
-
-            if ( empty( $names ) || ! is_array( $names ) ) {
-                return array();
-            }
-
-            if ( isset( $names['data'] ) && is_array( $names['data'] ) ) {
-                $names = $names['data'];
-            } elseif ( is_object( $names ) && isset( $names->data ) && is_array( $names->data ) ) {
-                $names = $names->data;
-            } elseif ( $names instanceof \Traversable ) {
-                $names = iterator_to_array( $names );
-            }
-
-            if ( empty( $names ) || ! is_array( $names ) ) {
-                return array();
-            }
-
-            $collected = array();
-            foreach ( $names as $entry ) {
-                $value = '';
-                if ( is_array( $entry ) ) {
-                    $keys = array( 'name', 'displayName', 'username', 'id' );
-                    foreach ( $keys as $key ) {
-                        if ( isset( $entry[ $key ] ) && '' !== (string) $entry[ $key ] ) {
-                            $value = (string) $entry[ $key ];
-                            break;
-                        }
-                    }
-                } elseif ( is_object( $entry ) ) {
-                    $keys = array( 'name', 'displayName', 'username', 'id' );
-                    foreach ( $keys as $key ) {
-                        if ( isset( $entry->$key ) && '' !== (string) $entry->$key ) {
-                            $value = (string) $entry->$key;
-                            break;
-                        }
-                    }
-                } else {
-                    $value = (string) $entry;
-                }
-
-                $value = trim( $value );
-                if ( '' !== $value ) {
-                    $collected[] = $value;
-                }
-            }
-
-            if ( empty( $collected ) ) {
-                return array();
-            }
-
-            return array_values( array_unique( $collected ) );
-        };
-
         $normalized_performer = $normalize_performer( $performer );
 
         if ( ! function_exists( 'lvjm_get_embed_and_actors' ) ) {
@@ -195,6 +339,10 @@ function lvjm_search_videos( $params = '' ) {
     wp_send_json(array(
         'videos'        => $videos,
         'errors'        => $errors,
+        'searched_data' => $searched_data,
+        'deep_summary'  => isset( $searched_data['deep_summary'] ) ? $searched_data['deep_summary'] : array(),
+        'deep_search'   => $deep_search,
+        'search_name'   => $search_name,
     ));
 
     wp_die();

--- a/admin/pages/page-import-videos.php
+++ b/admin/pages/page-import-videos.php
@@ -147,31 +147,65 @@ function lvjm_import_videos_page() {
 															<span id="kw-search" v-show="selectedPartnerObject.filters.search_by == 'keyword'">
 															<strong>- <?php esc_html_e( 'OR', 'lvjm_lang' ); ?> -</strong> <?php esc_html_e( 'Enter some keywords', 'lvjm_lang' ); ?> <input v-model="selectedKW" v-bind:disabled="searchingVideos" v-on:keyup.enter.prevent="searchVideos('create')" id="kw_s" type="text" placeholder="<?php esc_html_e( 'eg. ebony lesbian', 'lvjm_lang' ); ?>" name="kw_s" class="form-control" style="width:250px;">
 															</span>
-											<span id="performer-search" style="margin-left:8px;">
-												<label for="performer_s" class="sr-only"><?php esc_html_e( 'Performer', 'lvjm_lang' ); ?></label>
-												<input type="text" v-model="selectedPerformer" placeholder="<?php esc_attr_e( 'Performer (optional)', 'lvjm_lang' ); ?>" id="performer_s" name="performer_s" class="form-control" style="width:220px;">
-											</span>
+                                                                                        <span id="performer-search" style="margin-left:8px;">
+                                                                                                <label for="performer_s" class="sr-only"><?php esc_html_e( 'Performer', 'lvjm_lang' ); ?></label>
+                                                                                                <input type="text" v-model="selectedPerformer" placeholder="<?php esc_attr_e( 'Performer (optional)', 'lvjm_lang' ); ?>" id="performer_s" name="performer_s" class="form-control" style="width:220px;">
+                                                                                        </span>
+                                                                                        <span id="deep-search" style="margin-left:8px;">
+                                                                                                <label for="deep_search_name" class="sr-only"><?php esc_html_e( 'Deep Search name', 'lvjm_lang' ); ?></label>
+                                                                                                <input type="text" v-model="deepSearchName" v-bind:disabled="searchingVideos" v-on:keyup.enter.prevent="deepSearchVideos" id="deep_search_name" name="deep_search_name" class="form-control" style="width:220px;" placeholder="<?php esc_attr_e( 'Deep Search name', 'lvjm_lang' ); ?>">
+                                                                                        </span>
 
-														</div>
-													</div>
-												</div>
-												<div id="step-2" class="block-white sponsor-configured block-white-last" v-show="selectedPartnerObject.is_configured">
+                                                                                                                </div>
+                                                                                                        </div>
+                                                                                                </div>
+                                                                                                <div id="step-2" class="block-white sponsor-configured block-white-last" v-show="selectedPartnerObject.is_configured">
 													<span class="step">2</span>
-													<span v-show="videosHasBeenSearched">
-														<button class="btn btn-default" disabled><i class="fa fa-check" aria-hidden="true"></i> <?php esc_html_e( 'Search done!', 'lvjm_lang' ); ?></button>
-													</span>
-													<button v-show="!searchingVideos && !videosHasBeenSearched" v-on:click.prevent="searchVideos('create')" class="btn btn-info" v-bind:class="searchBtnClass" rel="tooltip" data-placement="top" v-bind:data-original-title="searchButtonTooltip"><i class="fa fa-search" aria-hidden="true"></i> <?php esc_html_e( 'Search videos', 'lvjm_lang' ); ?></button>
-													<button v-show="searchingVideos" disabled="disabled" class="btn btn-info"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> <?php esc_html_e( 'Searching videos...', 'lvjm_lang' ); ?></button>
-													<?php /* translators: %s: number of videos in the search results */ ?>
-													<small><i class="fa fa-info-circle" aria-hidden="true"></i> <?php printf( esc_html__( 'Each search displays up to %s unique videos at a time and excludes any videos already imported.', 'lvjm_lang' ), '{{data.videosLimit}}' ); ?></small>
-												</div>
-											</div>
-										</div>
-									</div>
-									<!-- / search videos block -->
-									<!-- results success block -->
-									<div class="row">
-										<div class="col-xs-12" v-show="videosCounter <= 0 && videosHasBeenSearched">                                        
+                                                                                                        <span v-show="videosHasBeenSearched">
+                                                                                                                <button class="btn btn-default" disabled><i class="fa fa-check" aria-hidden="true"></i> <?php esc_html_e( 'Search done!', 'lvjm_lang' ); ?></button>
+                                                                                                        </span>
+                                                                                                        <button v-show="!searchingVideos && !videosHasBeenSearched" v-on:click.prevent="searchVideos('create')" class="btn btn-info" v-bind:class="searchBtnClass" rel="tooltip" data-placement="top" v-bind:data-original-title="searchButtonTooltip"><i class="fa fa-search" aria-hidden="true"></i> <?php esc_html_e( 'Search videos', 'lvjm_lang' ); ?></button>
+                                                                                                        <button v-show="!searchingVideos" v-on:click.prevent="deepSearchVideos" class="btn btn-warning" v-bind:disabled="!deepSearchName || searchingVideos"><i class="fa fa-search-plus" aria-hidden="true"></i> <?php esc_html_e( 'Deep Search', 'lvjm_lang' ); ?></button>
+                                                                                                        <button v-show="searchingVideos" disabled="disabled" class="btn btn-info"><i class="fa fa-spinner fa-pulse" aria-hidden="true"></i> <?php esc_html_e( 'Searching videos...', 'lvjm_lang' ); ?></button>
+                                                                                                        <?php /* translators: %s: number of videos in the search results */ ?>
+                                                                                                        <small><i class="fa fa-info-circle" aria-hidden="true"></i> <?php printf( esc_html__( 'Each search displays up to %s unique videos at a time and excludes any videos already imported.', 'lvjm_lang' ), '{{data.videosLimit}}' ); ?></small>
+                                                                                                        <small><i class="fa fa-search-plus" aria-hidden="true"></i> <?php printf( esc_html__( 'Deep Search scans all straight categories for a name and returns up to %s matches, including duplicates.', 'lvjm_lang' ), '{{data.videosLimit}}' ); ?></small>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </div>
+                                                                        </div>
+                                                                        <!-- / search videos block -->
+                                                                        <div class="row" v-if="deepSearchActive && videosHasBeenSearched">
+                                                                                <div class="col-xs-12">
+                                                                                        <div class="alert alert-info margin-top-10" role="alert">
+                                                                                                <p class="margin-bottom-10"><strong><?php esc_html_e( 'Deep Search summary', 'lvjm_lang' ); ?></strong> <span v-if="deepSearchName">&mdash; {{deepSearchName}}</span></p>
+                                                                                                <div v-if="deepSearchSummary.length" class="table-responsive">
+                                                                                                        <table class="table table-condensed table-striped table-bordered">
+                                                                                                                <thead>
+                                                                                                                        <tr>
+                                                                                                                                <th><?php esc_html_e( 'Name', 'lvjm_lang' ); ?></th>
+                                                                                                                                <th><?php esc_html_e( 'Tag', 'lvjm_lang' ); ?></th>
+                                                                                                                                <th class="text-right"><?php esc_html_e( 'Videos found', 'lvjm_lang' ); ?></th>
+                                                                                                                        </tr>
+                                                                                                                </thead>
+                                                                                                                <tbody>
+                                                                                                                        <tr v-for="(row, index) in deepSearchSummary" v-bind:key="row.tag + '-' + index">
+                                                                                                                                <td>{{row.name}}</td>
+                                                                                                                                <td>{{row.tag}}</td>
+                                                                                                                                <td class="text-right">{{row.count}}</td>
+                                                                                                                        </tr>
+                                                                                                                </tbody>
+                                                                                                        </table>
+                                                                                                </div>
+                                                                                                <div v-else>
+                                                                                                        <em><?php esc_html_e( 'No videos matched the requested name in the straight catalog.', 'lvjm_lang' ); ?></em>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </div>
+                                                                        </div>
+                                                                        <!-- results success block -->
+                                                                        <div class="row">
+                                                                                <div class="col-xs-12" v-show="videosCounter <= 0 && videosHasBeenSearched">
 											<div v-if="videosSearchedErrors.code" class="alert alert-danger margin-top-10 text-center alert-dismissible" role="alert">
 												<button type="button" class="close" v-on:click.prevent="resetSearch" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
 												<p><i class="fa fa-exclamation-triangle" aria-hidden="true"></i> <strong>{{videosSearchedErrors.code}}</strong><br>{{videosSearchedErrors.message}}<br>-<br>{{videosSearchedErrors.solution}}</p>


### PR DESCRIPTION
## Summary
- add a deep search path that scans straight categories, keeps duplicates, and records summary data for matching performer names
- expose deep search controls and summary rendering in the import UI for immediate feedback on matches
- auto-create or update model CPT profiles during import, adding placeholder details and linking imported videos

## Testing
- php -l admin/class/class-lvjm-search-videos.php
- php -l admin/actions/ajax-search-videos.php
- php -l admin/actions/ajax-import-video.php

------
https://chatgpt.com/codex/tasks/task_e_68dab6e904fc83248d408c7a39687d54