### PR TITLE
Improve LiveJasmin search tracing and logging

### DIFF
--- a/admin/pages/page-import-videos.js
+++ b/admin/pages/page-import-videos.js
@@ -549,6 +549,8 @@ function LVJM_pageImportVideos() {
                         postData.multi_category_search = 1;
                     }
 
+                    var performer = this.selectedPerformer ? this.selectedPerformer.trim() : '';
+
                     var payload = {
                         action: 'lvjm_search_videos',
                         cat_s: cat_s,
@@ -560,7 +562,7 @@ function LVJM_pageImportVideos() {
                         nonce: LVJM_import_videos.ajax.nonce,
                         original_cat_s: cat_s.replace('&', '%%'),
                         partner: partner,
-                        performer: this.selectedPerformer
+                        performer: performer
                     };
 
                     this.executeSearch(payload, {


### PR DESCRIPTION
## Summary
- ensure admin search payload trims performer input and propagates it into AJAX calls
- update the search handler to include performer names in LiveJasmin API requests, expand deep search logging, and standardise debug messages
- harden model auto-profile creation by tracking creation state, returning attachment status, and logging profile events with the required format

## Testing
- php -l admin/actions/ajax-search-videos.php
- php -l admin/class/class-lvjm-search-videos.php
- php -l admin/actions/ajax-import-video.php

------
https://chatgpt.com/codex/tasks/task_e_68dac0f3e5e083249e5d792224ad1702